### PR TITLE
MSFT Script Encoding

### DIFF
--- a/src/magic/misc
+++ b/src/magic/misc
@@ -37,3 +37,7 @@
 
 0	string		\x3c?xml\x20version	XML document,
 >15	string		x			version: "%.3s"
+
+
+# CodeGate 2011 http://nopsrus.blogspot.com/2013/05/codegate-ctf-2011-binary-100-points.html
+0       string          \x23\x40\x7e\x5e    Windows Script Encoded Data (screnc.exe)


### PR DESCRIPTION
Microsoft Script Encoding format.  Used in CodeGate 2011.

Sample data: http://shell-storm.org/repo/CTF/CodeGate-2011/Binary/100/87C483A4CA85374E98FFB85FD5E867EC
