### PR TITLE
Run ldconfig on make install as it is required to use the plugins compre...

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -17,6 +17,7 @@ all: build
 install: build
 	make -C $(SRC_C_DIR) install
 	$(PYTHON) ./setup.py install
+	ldconfig || true
 
 build:
 	make -C $(SRC_C_DIR)


### PR DESCRIPTION
...ssd and zlibvalid.

This fixes the warnings:

 _WARNING: Failed to load plugin module 'compressd': libcompress42.so: cannot open shared object file: No such file or directory_

 _WARNING: Failed to load plugin module 'zlibvalid': libtinfl.so: cannot open shared object file: No such file or directory_

In combination with issue #32 this make binwalk stop working generally.

HTH,
Thomas
