### PR TITLE
Create directory for libs on Mac if nonexistent

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ then
 else
 	SONAME="-soname"
 	SOEXT="so"
-	INSTALL_OPTIONS="-D -m644"
+	INSTALL_OPTIONS="-m644"
 fi
 dnl AS_IF([test "x$enable_foo" != "xno"], [
 

--- a/src/C/compress/Makefile
+++ b/src/C/compress/Makefile
@@ -10,6 +10,7 @@ compress42.o:
 	$(CC) $(CFLAGS) compress42.c -c
 
 install:
+	mkdir -p $(DESTDIR)$(LIBDIR)
 	install $(INSTALL_OPTIONS) $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
 
 uninstall:

--- a/src/C/miniz/Makefile
+++ b/src/C/miniz/Makefile
@@ -10,6 +10,7 @@ tinfl.o:
 	$(CC) $(CFLAGS) -c tinfl.c
 
 install:
+	mkdir -p $(DESTDIR)$(LIBDIR)
 	install $(INSTALL_OPTIONS) $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
 
 uninstall:


### PR DESCRIPTION
Why was this left off for Mac? It's just as necessary as for Windows if installing into a prefix.
