### PR TITLE
Respect --prefix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -18,7 +18,11 @@ all: build
 
 install: build
 	if [ "$(BUILD_C_LIBS)" -eq "1" ]; then make -C $(SRC_C_DIR) install; fi
+ifeq ($(strip $(prefix)),)
 	$(PYTHON) ./setup.py install
+else
+	$(PYTHON) ./setup.py install --prefix=$(prefix)
+endif
 	if [ "$(BUILD_C_LIBS)" -eq "1" ] && [ "$(PLATFORM)" != "Cygwin" ]; then ldconfig || true; fi
 
 deps:


### PR DESCRIPTION
Currently, --prefix is not respected fully and it is impossible to install to a self-contained local prefix.
https://github.com/devttys0/binwalk/pull/51 solves this issue for the other libs, but the Python components are still installed in the system default path.

This passes --prefix to setup.py install to solve the issue.

autoreconf will have to be run. (Ideally, ./configure should be kept out of the repo via .gitignore and only provided in release tarballs.)
