### PR TITLE
build: fix semantics of AC_ARG_ENABLE (issue #63).

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -40,21 +40,21 @@ ida: build
 	if [ "$(IDA_DIR)" != "" ] && [ -e "$(IDA_DIR)/python/lib/python2.7" ]; then cp -R $(SRC_DIR)/binwalk $(IDA_DIR)/python/lib/python2.7/; fi 
 
 build:
-	if [ "$(BUILD_C_LIBS)" -eq "1" ]; then make -C $(SRC_C_DIR); fi
-	if [ "$(BUILD_BUNDLES)" -eq "1" ]; then make -C $(SRC_BUNDLES_DIR); fi
+	if [ "$(BUILD_C_LIBS)" -eq "yes" ]; then make -C $(SRC_C_DIR); fi
+	if [ "$(BUILD_BUNDLES)" -eq "yes" ]; then make -C $(SRC_BUNDLES_DIR); fi
 	$(PYTHON) ./setup.py build
 
 deps:
 	./deps.sh
 
 clean:
-	if [ "$(BUILD_C_LIBS)" -eq "1" ]; then make -C $(SRC_C_DIR) clean; fi
-	if [ "$(BUILD_BUNDLES)" -eq "1" ]; then make -C $(SRC_BUNDLES_DIR) clean; fi
+	if [ "$(BUILD_C_LIBS)" -eq "yes" ]; then make -C $(SRC_C_DIR) clean; fi
+	if [ "$(BUILD_BUNDLES)" -eq "yes" ]; then make -C $(SRC_BUNDLES_DIR) clean; fi
 	$(PYTHON) ./setup.py clean
 
 distclean: clean
-	if [ "$(BUILD_C_LIBS)" -eq "1" ]; then make -C $(SRC_C_DIR) distclean; fi
-	if [ "$(BUILD_BUNDLES)" -eq "1" ]; then make -C $(SRC_BUNDLES_DIR) distclean; fi
+	if [ "$(BUILD_C_LIBS)" -eq "yes" ]; then make -C $(SRC_C_DIR) distclean; fi
+	if [ "$(BUILD_BUNDLES)" -eq "yes" ]; then make -C $(SRC_BUNDLES_DIR) distclean; fi
 	rm -rf Makefile config.* *.cache
 
 uninstall:

--- a/configure.ac
+++ b/configure.ac
@@ -18,29 +18,24 @@ AC_ARG_WITH([python],
             [PYTHON=python])
 
 AC_ARG_ENABLE([clibs],
-              [AS_HELP_STRING([--disable-clibs], [do not build/install binwalk c libraries])],
-              [BUILD_C_LIBS=0],
-              [BUILD_C_LIBS=1])
+              [AS_HELP_STRING([--disable-clibs], [do not build/install binwalk c libraries])],,
+              [BUILD_C_LIBS=yes])
 
 AC_ARG_ENABLE([bundles],
-              [AS_HELP_STRING([--disable-bundles], [do not build/install any bundled software])],
-              [BUILD_BUNDLES=0],
-              [BUILD_BUNDLES=1])
+              [AS_HELP_STRING([--disable-bundles], [do not build/install any bundled software])],,
+              [BUILD_BUNDLES=yes])
 
 AC_ARG_ENABLE([libmagic],
-              [AS_HELP_STRING([--disable-libmagic], [do not build/install the bundled libmagic library])],
-              [BUILD_MAGIC=0],
-              [BUILD_MAGIC=1])
+              [AS_HELP_STRING([--disable-libmagic], [do not build/install the bundled libmagic library])],,
+              [BUILD_MAGIC=yes])
 
 AC_ARG_ENABLE([libfuzzy],
-              [AS_HELP_STRING([--disable-libfuzzy], [do not build/install the bundled libfuzzy library])],
-              [BUILD_FUZZY=0],
-              [BUILD_FUZZY=1])
+              [AS_HELP_STRING([--disable-libfuzzy], [do not build/install the bundled libfuzzy library])],,
+              [BUILD_FUZZY=yes])
 
 AC_ARG_ENABLE([pyqtgraph],
-              [AS_HELP_STRING([--disable-pyqtgraph], [do not build/install the bundled pyqtgraph module])],
-              [BUILD_PYQTGRAPH=0],
-              [BUILD_PYQTGRAPH=1])
+              [AS_HELP_STRING([--disable-pyqtgraph], [do not build/install the bundled pyqtgraph module])],,
+              [BUILD_PYQTGRAPH=yes])
 
 CFLAGS="-Wall -fPIC $CFLAGS"
 INSTALL_OPTIONS="-m644"
@@ -59,28 +54,28 @@ else
 	SOEXT="so"
 fi
 
-if test "$BUILD_BUNDLES" == "0"
+if test "$BUILD_BUNDLES" == "no"
 then
-    BUILD_MAGIC=0
-    BUILD_FUZZY=0
-    BUILD_PYQTGRAPH=0
+    BUILD_MAGIC=no
+    BUILD_FUZZY=no
+    BUILD_PYQTGRAPH=no
 fi
 
-if test "$BUILD_MAGIC" != "0"
+if test "$BUILD_MAGIC" != "no"
 then
     rm -rf $(ls ./src/bundles/file-*.tar.gz | sed -e 's/\.tar\.gz//')
     (cd ./src/bundles && tar -zxvf file-*.tar.gz > /dev/null)
     (cd ./src/bundles/file-*/ && ./configure) || exit 1
 fi
 
-if test "$BUILD_FUZZY" != "0"
+if test "$BUILD_FUZZY" != "no"
 then
     rm -rf $(ls ./src/bundles/ssdeep-*.tar.gz | sed -e 's/\.tar\.gz//')
     (cd ./src/bundles && tar -zxvf ssdeep-*.tar.gz > /dev/null)
     (cd ./src/bundles/ssdeep-*/ && ./configure) || exit 1
 fi
 
-if test "$BUILD_PYQTGRAPH" != "0"
+if test "$BUILD_PYQTGRAPH" != "no"
 then
     (cd ./src/bundles && tar -zxvf pyqtgraph-*.tar.gz > /dev/null)
 fi

--- a/src/bundles/Makefile
+++ b/src/bundles/Makefile
@@ -6,12 +6,12 @@ PYQTGRAPH_VERSION=`ls pyqtgraph-*.tar.gz | cut -d'-' -f2 | cut -d '.' -f1,2,3`
 .PHONY: all clean_libs clean distclean
 
 all:
-	if [ "$(BUILD_FUZZY)" -eq "1" ]; then make -C ssdeep-$(SSDEEP_VERSION) libfuzzy.la; fi
-	if [ "$(BUILD_FUZZY)" -eq "1" ]; then cp ssdeep-$(SSDEEP_VERSION)/.libs/libfuzzy.$(SOEXT) $(LIB_DIR); fi
-	if [ "$(BUILD_MAGIC)" -eq "1" ]; then make -C file-$(FILE_VERSION)/src magic.h; fi # This must be done first for OSX, else MAGIC_VERSION is undefined
-	if [ "$(BUILD_MAGIC)" -eq "1" ]; then make -C file-$(FILE_VERSION)/src libmagic.la; fi
-	if [ "$(BUILD_MAGIC)" -eq "1" ]; then cp file-$(FILE_VERSION)/src/.libs/libmagic.$(SOEXT) $(LIB_DIR); fi
-	if [ "$(BUILD_PYQTGRAPH)" -eq "1" ] && [ ! -e $(LIB_DIR)/pyqtgraph ]; then cp -R pyqtgraph-$(PYQTGRAPH_VERSION)/pyqtgraph $(LIB_DIR)/; fi
+	if [ "$(BUILD_FUZZY)" -eq "yes" ]; then make -C ssdeep-$(SSDEEP_VERSION) libfuzzy.la; fi
+	if [ "$(BUILD_FUZZY)" -eq "yes" ]; then cp ssdeep-$(SSDEEP_VERSION)/.libs/libfuzzy.$(SOEXT) $(LIB_DIR); fi
+	if [ "$(BUILD_MAGIC)" -eq "yes" ]; then make -C file-$(FILE_VERSION)/src magic.h; fi # This must be done first for OSX, else MAGIC_VERSION is undefined
+	if [ "$(BUILD_MAGIC)" -eq "yes" ]; then make -C file-$(FILE_VERSION)/src libmagic.la; fi
+	if [ "$(BUILD_MAGIC)" -eq "yes" ]; then cp file-$(FILE_VERSION)/src/.libs/libmagic.$(SOEXT) $(LIB_DIR); fi
+	if [ "$(BUILD_PYQTGRAPH)" -eq "yes" ] && [ ! -e $(LIB_DIR)/pyqtgraph ]; then cp -R pyqtgraph-$(PYQTGRAPH_VERSION)/pyqtgraph $(LIB_DIR)/; fi
 
 clean_libs:
 	rm -f $(LIB_DIR)/libmagic.$(SOEXT)
@@ -19,8 +19,8 @@ clean_libs:
 	rm -rf $(LIB_DIR)/pyqtgraph
 
 clean: clean_libs
-	if [ "$(BUILD_FUZZY)" -eq "1" ]; then make -C ssdeep-$(SSDEEP_VERSION) clean; fi
-	if [ "$(BUILD_MAGIC)" -eq "1" ]; then make -C file-$(FILE_VERSION) clean; fi
+	if [ "$(BUILD_FUZZY)" -eq "yes" ]; then make -C ssdeep-$(SSDEEP_VERSION) clean; fi
+	if [ "$(BUILD_MAGIC)" -eq "yes" ]; then make -C file-$(FILE_VERSION) clean; fi
 
 distclean: clean_libs
 	rm -rf ./ssdeep-$(SSDEEP_VERSION)


### PR DESCRIPTION
This makes sure that ./configure --enable-clibs does not instead
_disable_ c libraries, as it did before. This is important for
packagers as the usual semantics is for --enable/--disable to both
work and do the right thing.

See https://www.flameeyes.eu/autotools-mythbuster/autoconf/arguments.html
for the proper semantics of the macro.
