### PR TITLE
Move most of binwalk's tinfl additions to a separate file

### DIFF
--- a/src/C/miniz/Makefile
+++ b/src/C/miniz/Makefile
@@ -2,12 +2,12 @@ LIBNAME=libtinfl.$(SOEXT)
 
 all: $(LIBNAME)
 
-$(LIBNAME): tinfl.o
-	$(CC) $(CFLAGS) $(CPPFLAGS) -shared -Wl,$(SONAME),$(LIBNAME) tinfl.o -o $(LIBNAME) $(LDFLAGS)
+$(LIBNAME): tinfl_wrapper.o
+	$(CC) $(CFLAGS) $(CPPFLAGS) -shared -Wl,$(SONAME),$(LIBNAME) tinfl_wrapper.o -o $(LIBNAME) $(LDFLAGS)
 	chmod +x $(LIBNAME)
 
-tinfl.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c tinfl.c
+tinfl_wrapper.o:
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c tinfl_wrapper.c
 
 install:
 	mkdir -p $(DESTDIR)$(LIBDIR)

--- a/src/C/miniz/tinfl.c
+++ b/src/C/miniz/tinfl.c
@@ -8,7 +8,6 @@
 #ifndef TINFL_HEADER_INCLUDED
 #define TINFL_HEADER_INCLUDED
 
-#include <stdio.h>
 #include <stdlib.h>
 
 typedef unsigned char mz_uint8;
@@ -69,10 +68,6 @@ size_t tinfl_decompress_mem_to_mem(void *pOut_buf, size_t out_buf_len, const voi
 // Returns 1 on success or 0 on failure.
 typedef int (*tinfl_put_buf_func_ptr)(const void* pBuf, int len, void *pUser);
 int tinfl_decompress_mem_to_callback(const void *pIn_buf, size_t *pIn_buf_size, tinfl_put_buf_func_ptr pPut_buf_func, void *pPut_buf_user, int flags);
-
-// Checks to see if the first block of data in in_buf is valid zlib compressed data.
-// Returns 1 if valid, 0 if invalid.
-int is_valid_zlib_data(char *in_buf, size_t in_buf_size);
 
 struct tinfl_decompressor_tag; typedef struct tinfl_decompressor_tag tinfl_decompressor;
 
@@ -573,117 +568,6 @@ int tinfl_decompress_mem_to_callback(const void *pIn_buf, size_t *pIn_buf_size, 
   return result;
 }
 
-#define BLOCK_SIZE (32*1024)
-char *inflate_block(char *buf, size_t buf_size)
-{
-	size_t out_size = BLOCK_SIZE;
-	return (char *) tinfl_decompress_mem_to_heap((const void *) buf, buf_size, (size_t *) &out_size, 0);
-}
-
-/* CJH */
-
-int is_deflated_callback(const void *pBuf, int len, void *pUser)
-{
-	int *decomp_size = pUser;
-
-	*decomp_size += len;
-
-	if(len > 0)
-	{
-		return 1;
-	}
-
-        return 0;
-}
-
-/*
- * Tries to determine if a given buffer contains valid deflated data.
- *
- * @buf                  - The buffer of data to check for deflated data.
- * @buf_size             - The size of @buf.
- * @includes_zlib_header - Set to 1 if the buffer should start with a valid zlib header.
- * 
- * Returns the size of the inflated data if @buf inflated to a value larger than 32KB, 
- * or if it contained a valid zlib header/footer; else, returns 0.
- *
- * Thus, it is recommended to provide more than 32KB of data in @buf for the most accurate results.
- */
-int is_deflated(char *buf, size_t buf_size, int includes_zlib_header)
-{
-  int flags = TINFL_FLAG_HAS_MORE_INPUT;
-  int retval = 0, decomp_size = 0;
-
-  if(includes_zlib_header)
-  {
-    flags |= TINFL_FLAG_PARSE_ZLIB_HEADER | TINFL_FLAG_COMPUTE_ADLER32;
-  }
-
-  retval = tinfl_decompress_mem_to_callback(buf, &buf_size, is_deflated_callback, (void *) &decomp_size, flags);
-
-  if(retval == 1 || decomp_size > BLOCK_SIZE)
-  {
-    return decomp_size;
-  }
-
-  return 0;
-}
-
-int inflate_raw_file_callback(const void *pBuf, int len, void *pUser)
-{
-	if(fwrite(pBuf, 1, len, (FILE *) pUser) == len)
-	{
-		return 1;
-	}
-	
-	return 0;
-}
-
-/* Inflates a file containing raw deflated data.
- *
- * @in_file  - Input file containing raw deflated data.
- * @out_file - Output file where inflated data will be saved.
- *
- * Returns void.
- */
-void inflate_raw_file(char *in_file, char *out_file)
-{
-	char *compressed_data = NULL;
-	size_t in_size = 0, nbytes = 0;
-	FILE *fp_in = NULL, *fp_out = NULL;
-
-	fp_in = fopen(in_file, "rb");
-	if(fp_in)
-	{
-		fp_out = fopen(out_file, "wb");
-		if(fp_out)
-		{
-	
-			fseek(fp_in, 0L, SEEK_END);
-			in_size = ftell(fp_in);
-			fseek(fp_in, 0L, SEEK_SET);
-
-			compressed_data = malloc(in_size);
-			if(compressed_data)
-			{
-				memset(compressed_data, 0, in_size);
-
-				nbytes = fread(compressed_data, 1, in_size, fp_in);
-				if(nbytes > 0)
-				{
-					tinfl_decompress_mem_to_callback(compressed_data, &nbytes, inflate_raw_file_callback, (void *) fp_out, 0);
-				}
-				
-				free(compressed_data);
-			}
-		}
-	}
-
-	if(fp_in) fclose(fp_in);
-	if(fp_out) fclose(fp_out);
-
-	return;
-}
-
 #endif // #ifndef TINFL_HEADER_FILE_ONLY
 
 /*
@@ -712,18 +596,3 @@ void inflate_raw_file(char *in_file, char *out_file)
 
   For more information, please refer to <http://unlicense.org/>
 */
-
-#ifdef MAIN
-int main(int argc, char *argv[])
-{
-	if(argc != 3)
-	{
-		fprintf(stderr, "Usage: %s <input file> <output file>\n", argv[0]);
-		return EXIT_FAILURE;
-	}
-
-	inflate_raw_file(argv[1], argv[2]);
-	
-	return EXIT_SUCCESS;
-}
-#endif

--- a/src/C/miniz/tinfl_wrapper.c
+++ b/src/C/miniz/tinfl_wrapper.c
@@ -1,0 +1,133 @@
+#include <stdio.h>
+#include <string.h>
+#include "tinfl.c"
+
+// Checks to see if the first block of data in in_buf is valid zlib compressed data.
+// Returns 1 if valid, 0 if invalid.
+int is_valid_zlib_data(char *in_buf, size_t in_buf_size);
+
+#define BLOCK_SIZE (32*1024)
+char *inflate_block(char *buf, size_t buf_size)
+{
+	size_t out_size = BLOCK_SIZE;
+	return (char *) tinfl_decompress_mem_to_heap((const void *) buf, buf_size, (size_t *) &out_size, 0);
+}
+
+/* CJH */
+
+int is_deflated_callback(const void *pBuf, int len, void *pUser)
+{
+	int *decomp_size = pUser;
+
+	*decomp_size += len;
+
+	if(len > 0)
+	{
+		return 1;
+	}
+
+        return 0;
+}
+
+/*
+ * Tries to determine if a given buffer contains valid deflated data.
+ *
+ * @buf                  - The buffer of data to check for deflated data.
+ * @buf_size             - The size of @buf.
+ * @includes_zlib_header - Set to 1 if the buffer should start with a valid zlib header.
+ * 
+ * Returns the size of the inflated data if @buf inflated to a value larger than 32KB, 
+ * or if it contained a valid zlib header/footer; else, returns 0.
+ *
+ * Thus, it is recommended to provide more than 32KB of data in @buf for the most accurate results.
+ */
+int is_deflated(char *buf, size_t buf_size, int includes_zlib_header)
+{
+  int flags = TINFL_FLAG_HAS_MORE_INPUT;
+  int retval = 0, decomp_size = 0;
+
+  if(includes_zlib_header)
+  {
+    flags |= TINFL_FLAG_PARSE_ZLIB_HEADER | TINFL_FLAG_COMPUTE_ADLER32;
+  }
+
+  retval = tinfl_decompress_mem_to_callback(buf, &buf_size, is_deflated_callback, (void *) &decomp_size, flags);
+
+  if(retval == 1 || decomp_size > BLOCK_SIZE)
+  {
+    return decomp_size;
+  }
+
+  return 0;
+}
+
+int inflate_raw_file_callback(const void *pBuf, int len, void *pUser)
+{
+	if(fwrite(pBuf, 1, len, (FILE *) pUser) == len)
+	{
+		return 1;
+	}
+	
+	return 0;
+}
+
+/* Inflates a file containing raw deflated data.
+ *
+ * @in_file  - Input file containing raw deflated data.
+ * @out_file - Output file where inflated data will be saved.
+ *
+ * Returns void.
+ */
+void inflate_raw_file(char *in_file, char *out_file)
+{
+	char *compressed_data = NULL;
+	size_t in_size = 0, nbytes = 0;
+	FILE *fp_in = NULL, *fp_out = NULL;
+
+	fp_in = fopen(in_file, "rb");
+	if(fp_in)
+	{
+		fp_out = fopen(out_file, "wb");
+		if(fp_out)
+		{
+	
+			fseek(fp_in, 0L, SEEK_END);
+			in_size = ftell(fp_in);
+			fseek(fp_in, 0L, SEEK_SET);
+
+			compressed_data = malloc(in_size);
+			if(compressed_data)
+			{
+				memset(compressed_data, 0, in_size);
+
+				nbytes = fread(compressed_data, 1, in_size, fp_in);
+				if(nbytes > 0)
+				{
+					tinfl_decompress_mem_to_callback(compressed_data, &nbytes, inflate_raw_file_callback, (void *) fp_out, 0);
+				}
+				
+				free(compressed_data);
+			}
+		}
+	}
+
+	if(fp_in) fclose(fp_in);
+	if(fp_out) fclose(fp_out);
+
+	return;
+}
+
+#ifdef MAIN
+int main(int argc, char *argv[])
+{
+	if(argc != 3)
+	{
+		fprintf(stderr, "Usage: %s <input file> <output file>\n", argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	inflate_raw_file(argv[1], argv[2]);
+	
+	return EXIT_SUCCESS;
+}
+#endif


### PR DESCRIPTION
This will make downstream use of unbundled tinfl easier.
