### PR TITLE
Make the color options not mutual exclusive

### DIFF
--- a/src/binwalk/modules/hexdiff.py
+++ b/src/binwalk/modules/hexdiff.py
@@ -31,15 +31,15 @@ class HexDiff(Module):
                    description='Perform a hexdump / diff of a file or files'),
             Option(short='G',
                    long='green',
-                   kwargs={'show_green' : True, 'show_blue' : False, 'show_red' : False},
+                   kwargs={'show_green' : True},
                    description='Only show lines containing bytes that are the same among all files'),
             Option(short='i',
                    long='red',
-                   kwargs={'show_red' : True, 'show_blue' : False, 'show_green' : False},
+                   kwargs={'show_red' : True},
                    description='Only show lines containing bytes that are different among all files'),
             Option(short='U',
                    long='blue',
-                   kwargs={'show_blue' : True, 'show_red' : False, 'show_green' : False},
+                   kwargs={'show_blue' : True},
                    description='Only show lines containing bytes that are different among some files'),
             Option(short='w',
                    long='terse',
@@ -48,9 +48,9 @@ class HexDiff(Module):
     ]
 
     KWARGS = [
-            Kwarg(name='show_red', default=True),
-            Kwarg(name='show_blue', default=True),
-            Kwarg(name='show_green', default=True),
+            Kwarg(name='show_red', default=False),
+            Kwarg(name='show_blue', default=False),
+            Kwarg(name='show_green', default=False),
             Kwarg(name='terse', default=False),
             Kwarg(name='enabled', default=False),
     ]
@@ -172,6 +172,10 @@ class HexDiff(Module):
             loop_count += 1
 
     def init(self):
+        # To mimic expected behavior, if all options are False, we show everything
+        if not any([self.show_red, self.show_green, self.show_blue]):
+            self.show_red = self.show_green = self.show_blue = True
+
         # Always disable terminal formatting, as it won't work properly with colorized output
         self.config.display.fit_to_screen = False
 


### PR DESCRIPTION
This commit allows to combine --red, --blue and --green options instead of the mutual exclusive behavior.
It is therefore possible to show, for example, only red and blue, that it to say every pieces of files that have changed.
