### PR TITLE
Update header for TRX to include versioning and offsets

### DIFF
--- a/src/binwalk/magic/firmware
+++ b/src/binwalk/magic/firmware
@@ -90,21 +90,33 @@
 
 # trx image file
 0       string        HDR0    TRX firmware header, little endian, header size: 28 bytes,
->4      lelong        <1      {invalid}
->4      lelong        x       image size: %d bytes,
+>4      ulelong       x       image size: %d bytes,
 >8      ulelong       x       CRC32: 0x%X
 >12     uleshort      x       flags: 0x%X,
->14     uleshort      >5      {invalid}
->14     leshort       x       version: %d
+>14     uleshort      1       version: %d,
+>>16    ulelong       x       loader offset: 0x%X,
+>>20    ulelong       x       linux kernel offset: 0x%X,
+>>24    ulelong       x       rootfs offset: 0x%X
+>>24    ulelong       0       {invalid}
 
-0       string        0RDH    TRX firmware header, big endian, header size: 28 bytes,
->4      belong        <1      {invalid}
->4      belong        x       image size: %d bytes,
->8      ubelong       x       CRC32: 0x%X
->12     ubeshort      x       flags: 0x%X,
->14     ubeshort      >5      {invalid}
->14     beshort       x       version: %d
+0       string        HDR0    TRX firmware header, little endian, header size: 28 bytes,
+>4      ulelong       x       image size: %d bytes,
+>8      ulelong       x       CRC32: 0x%X
+>12     uleshort      x       flags: 0x%X,
+>14     uleshort      1       version: %d,
+>>16    ulelong       x       kernel offset: 0x%X,
+>>20    ulelong       x       rootfs offset: 0x%X
+>>24    ulelong       !0      {invalid}
 
+0       string        HDR0    TRX firmware header, little endian, header size: 32 bytes,
+>4      ulelong       x       image size: %d bytes,
+>8      ulelong       x       CRC32: 0x%X
+>12     uleshort      x       flags: 0x%X,
+>14     uleshort      2       version: %d,
+>>16    ulelong       x       loader offset: 0x%X,
+>>20    ulelong       x       linux kernel offset: 0x%X,
+>>24    ulelong       x       rootfs offset: 0x%X,
+>>28    ulelong       x       bin-header offset: 0x%X
 
 # Ubicom firmware image
 0       belong    0xFA320080    Ubicom firmware header,


### PR DESCRIPTION
1. Added display of loader/kernel/rootfs offsets based on version of the TRX firmware header.
2. Removed big endian TRX signature since the code converts to little endian. (Unless there are big endian TRX headers out in the wild?)

Also, why do all integer types default to signed by default? It seems that having unsigned as the default would make more sense.

Refs:
http://wiki.openwrt.org/doc/techref/header
https://dev.openwrt.org/browser/trunk/tools/firmware-utils/src/trx.c
