### PR TITLE
Fix trx image extraction

### DIFF
--- a/src/binwalk/core/magic.py
+++ b/src/binwalk/core/magic.py
@@ -699,19 +699,25 @@ class Magic(object):
                                 dvalue_tuple += (dvalue,)
 
                             # Format the tag string
-                            tags[tag_name] = tag_value % dvalue_tuple
-                        # Else, just use the raw tag value
-                        else:
-                            tags[tag_name] = tag_value
+                            tag_value = tag_value % dvalue_tuple
 
                         # Some tag values are intended to be integer values, so
                         # try to convert them as such
                         try:
-                            tags[tag_name] = int(tags[tag_name], 0)
+                            tag_value = int(tag_value, 0)
                         except KeyboardInterrupt as e:
                             raise e
                         except Exception as e:
                             pass
+
+                        if tag_name in tags:
+                            if isinstance(tags[tag_name], list):
+                                tags[tag_name].append(tag_value)
+                            else:
+                                tags[tag_name] = [tags[tag_name], tag_value]
+
+                        else:
+                            tags[tag_name] = tag_value
 
                     # Abort processing soon as this signature is marked invalid, unless invalid results
                     # were explicitly requested. This means that the sooner invalid checks are made in a
@@ -821,7 +827,12 @@ class Magic(object):
                                 self.display_once.add(signature.title)
 
                         # Append the result to the results list
-                        results.append(SignatureResult(**tags))
+                        r = SignatureResult(**tags)
+                        for x in tags.keys():
+                            binwalk.core.common.debug("tags key:%s, value:%s" % (str(x), str(tags[x])))
+                        results.append(r)
+                        binwalk.core.common.debug(
+                            "scan for %s @%d r.size:%d [%s]" % (r.name, r.offset, r.size, r.description))
 
                         # Add this offset to the matched_offsets set, so that it can be ignored by
                         # subsequent loops.

--- a/src/binwalk/magic/firmware
+++ b/src/binwalk/magic/firmware
@@ -103,7 +103,7 @@
 >48     string        x         root device: "%s"
 
 # trx image file
-0       string        HDR0    TRX firmware header, little endian,
+0       string        HDR0    TRX firmware header, little endian, {header:%s}
 >4      lelong        <1      {invalid}
 >4      ulelong       x       image size: %d bytes,
 >8      ulelong       x       CRC32: 0x%X,
@@ -111,14 +111,14 @@
 >14     uleshort      !1
 >>14    uleshort      !2      {invalid}
 >14     uleshort      2       version: %d, header size: 32 bytes,
->>16    ulelong       x       loader offset: 0x%X,
->>20    ulelong       x       linux kernel offset: 0x%X,
->>24    ulelong       x       rootfs offset: 0x%X,
->>28    ulelong       x       bin-header offset: 0x%X
+>>16    ulelong       x       loader offset: 0x%X,{ offsets:%d}
+>>20    ulelong       x       linux kernel offset: 0x%X, {offsets:%d}
+>>24    ulelong       x       rootfs offset: 0x%X, {offsets:%d}
+>>28    ulelong       x       bin-header offset: 0x%X, {offsets:%d}
 >14     uleshort      1       version: %d, header size: 28 bytes,
->>16    ulelong       x       loader offset: 0x%X,
->>20    ulelong       x       linux kernel offset: 0x%X,
->>24    ulelong       x       rootfs offset: 0x%X
+>>16    ulelong       x       loader offset: 0x%X, {offsets:%d}
+>>20    ulelong       x       linux kernel offset: 0x%X, {offsets:%d}
+>>24    ulelong       x       rootfs offset: 0x%X, {offsets:%d}
 
 14      string        U2ND      BIN-Header,
 >4      ulelong       !0        {invalid}

--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -191,8 +191,26 @@ class Extractor(Module):
         except Exception as e:
             return
 
+        # Keep the header result to calculate result size when it doesn't have size
+        if hasattr(r, 'header') and r.valid:
+            self.header_r = r
+
         if not r.size:
             size = r.file.size - r.offset
+
+            # has header result, calculate its size by header
+            if hasattr(self, 'header_r'):
+                header_r = self.header_r
+                if r != header_r and hasattr(header_r, "offsets"):
+                    # calculate the size by the offset which is defined in header
+                    for index, offset in enumerate(self.header_r.offsets):
+                        if r.offset == offset + self.header_r.offset:
+                            break;
+
+                    if (index + 1) < len(self.header_r.offsets):
+                        size = self.header_r.offsets[index + 1] - self.header_r.offsets[index]
+                    else:
+                        size = r.file.size - r.offset
         else:
             size = r.size
 

--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -203,12 +203,16 @@ class Extractor(Module):
                 header_r = self.header_r
                 if r != header_r and hasattr(header_r, "offsets"):
                     # calculate the size by the offset which is defined in header
-                    for index, offset in enumerate(self.header_r.offsets):
-                        if r.offset == offset + self.header_r.offset:
-                            break;
+                    for index, offset in enumerate(header_r.offsets):
+                        # offset in header is invalid or it already in the last offset
+                        if offset == 0 or (index + 1) == len(header_r.offsets):
+                            break
 
-                    if (index + 1) < len(self.header_r.offsets):
-                        size = self.header_r.offsets[index + 1] - self.header_r.offsets[index]
+                        # find the correct offset in header offsets and caculate the size
+                        if r.offset == offset + header_r.offset and self.header_r.offsets[index + 1] != 0:
+                            size = self.header_r.offsets[index + 1] - offset
+                            break
+
         else:
             size = r.size
 

--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -209,8 +209,6 @@ class Extractor(Module):
 
                     if (index + 1) < len(self.header_r.offsets):
                         size = self.header_r.offsets[index + 1] - self.header_r.offsets[index]
-                    else:
-                        size = r.file.size - r.offset
         else:
             size = r.size
 


### PR DESCRIPTION
In trx image, some payload doesn't have size field like lzma. Its size can be calculated by offsets which is defined in the trx header. Otherwise the data from extraction will be corrupt.