### PR TITLE
Fix Ubiquiti partiton PART and END headers

### DIFF
--- a/src/binwalk/magic/firmware
+++ b/src/binwalk/magic/firmware
@@ -453,16 +453,16 @@
 >4      byte        0           {invalid},
 >4      string      x           version: "%s"
 
-4   string      \x00\x00\x00\x00PART    Ubiquiti partition header,
+-4  string      \x00\x00\x00\x00PART    Ubiquiti partition header,
 >0  byte        x                       header size: 56 bytes,
->8  byte        0                       {invalid}
->8  string      x                       name: "%s",
->44 ubelong     x                       base address: 0x%.8X,
->52 belong      x                       data size: %d bytes{size:%d}
+>0  byte        0                       {invalid}
+>0  string      x                       name: "%s",
+>40 ubelong     x                       base address: 0x%.8X,
+>48 belong      x                       data size: %d bytes{size:%d}
 
-4   string      \x00\x00\x00\x00END\x2e Ubiquiti end header, header size: 12 bytes,
->12 belong      !0                      {invalid},
->8  ubelong     x                       cumulative ~CRC32: 0x%.8X
+-4  string      \x00\x00\x00\x00END\x2e Ubiquiti end header, header size: 12 bytes,
+>8  belong      !0                      {invalid},
+>4  ubelong     x                       cumulative ~CRC32: 0x%.8X
 
 
 # Found in DIR-100 firmware


### PR DESCRIPTION
The zero-padding used to identify the PART and END headers is not part of the header itself but rather padding from previous data structures.

Also offsets were wrong, resulting in wrong base addresses and partition sizes.

Before:
![binwalk_broken](https://user-images.githubusercontent.com/2042858/35657505-1cc7ff56-06fd-11e8-993d-d91368271568.png)

After:
![binwalk_fixed](https://user-images.githubusercontent.com/2042858/35657504-1cab825e-06fd-11e8-86a7-44b5ec417ba0.png)

