### PR TITLE
Add magic for signed Ubiquiti end headers

### DIFF
--- a/src/binwalk/magic/firmware
+++ b/src/binwalk/magic/firmware
@@ -464,6 +464,8 @@
 >12 belong      !0                      {invalid},
 >8  ubelong     x                       cumulative ~CRC32: 0x%.8X
 
+-4   string      \x00\x00\x00\x00ENDS   Signed Ubiquiti end header, RSA 2048 bit, header size: 264 bytes
+>260 ubelong     !0                     {invalid}
 
 # Found in DIR-100 firmware
 0       string      AIH0        AIH0 firmware header, header size: 48,


### PR DESCRIPTION
More modern Ubiquiti devices use signed firmware with a different end header.
This PR adds support for the new signed end headers.

The new header start with the string "ENDS" which is followed by a 2048 bit
RSA sha1 signature.