### PR TITLE
Fix broken QNX4/6 detection

### DIFF
--- a/src/binwalk/magic/filesystems
+++ b/src/binwalk/magic/filesystems
@@ -681,8 +681,13 @@
 >16     lelong   x       {strlen:%d}
 >20     string   x       first file name: "{string}"
 
-# QNX6 filesystem
-0       string   \xEB\x10\x90\x00    QNX6 filesystem
+# QNX4 Filesystem
+0       string   \xEB\x10\x90\x00    QNX4 Boot Block
+
+# QNX6 Filesystem
+# https://www.forensicfocus.com/Forums/viewtopic/t=16846/
+# Also known as the QNX6_SUPER_MAGIC (in linux sources)
+0       string   \x68\x19\x11\x22    QNX6 Super Block
 
 # QNX IFS
 0       string   \xEB\x7E\xFF\x00    QNX IFS


### PR DESCRIPTION
The previous QNX detection was erroneously using the QNX4 Boot block magic, but labelled QNX6. 
This PR fixes the labels and add the proper QNX6 Super Block magic, known as QNX6_SUPER_MAGIC.

For further details see: 
https://www.forensicfocus.com/Forums/viewtopic/t=16846/
https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/include/uapi/linux/magic.h#L49
https://github.com/torvalds/linux/blob/master/fs/qnx6/inode.c