### PR TITLE
Add signature of flattened device trees

### DIFF
--- a/src/binwalk/magic/firmware
+++ b/src/binwalk/magic/firmware
@@ -870,3 +870,29 @@
 >0x24      ulelong     0
 >0x28      ulelong     0
 >0x2c      ulelong     0
+
+# Flattened device tree
+# Device Tree specification v0.2
+# https://github.com/devicetree-org/devicetree-specification/releases/download/v0.2/devicetree-specification-v0.2.pdf
+# Device tree magic
+0           ubelong   0xd00dfeed  Flattened device tree,
+# Device tree size, may not be less than header size (40)
+>4          ubelong   <40         {invalid}
+>4          ubelong   x               size: %d bytes,
+# Offset of structure block, may not be less than header size (40), must be aligned to 4 byte boundary
+>8          ubelong   <40         {invalid}
+>8          ubelong&3 !0          {invalid}
+>8          ubelong   !0
+# First node of structure block, must be either FDT_BEGIN_NODE (1), FDT_NOP (4) or FDT_END (9)
+>>(8.L)     ubelong   !1
+>>>(8.L)    ubelong   !4
+>>>>(8.L)   ubelong   !9          {invalid}
+>>>>(8.L)   ubelong   9               empty device tree,
+# Offset of strings block, may not be less than header size (40)
+>12         ubelong   <40         {invalid}
+# Version
+>20         ubelong   x               version: %d
+# Size of strings block, must be greater than 0
+>32         ubelong   0           {invalid}
+# Size of structure block, must be greater than 0
+>36         ubelong   0           {invalid}


### PR DESCRIPTION
This commit adds support for automated discovery of flattened device trees which are very common in embedded device firmware.

Before binwalk was unable to identify device trees:
```
[tsys@sunsetshimmer cortexa9]$ binwalk zImage_dtb 

DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------
36            0x24            Linux kernel ARM boot executable zImage (little-endian), load address: "0x00000000", end address: "0x003C7C38"
18148         0x46E4          gzip compressed data, maximum compression, from Unix, NULL date (1970-01-01 00:00:00)
```

With this commit applied binwalk identifies devicetrees correctly:
```
[tsys@sunsetshimmer cortexa9]$ binwalk zImage_dtb 

DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------
36            0x24            Linux kernel ARM boot executable zImage (little-endian), load address: "0x00000000", end address: "0x003C7C38"
18148         0x46E4          gzip compressed data, maximum compression, from Unix, NULL date (1970-01-01 00:00:00)
3963960       0x3C7C38        Flattened device tree, size: 14737 bytes, version: 17
```

While you are at it; would you mind doing a new release of binwalk? Most OS distributions do only package releases and the last one is from 2015. There have been a lot of awesome additions to binwalk since then. It would be really nice if all users could benefit from an up to date binwalk simply by installing the release provided by their distribution.

Signed-off-by: Tobias Schramm <tobleminer@gmail.com>