### PR TITLE
Add signature for Ubiquiti firmware additional data

### DIFF
--- a/src/binwalk/magic/firmware
+++ b/src/binwalk/magic/firmware
@@ -467,6 +467,20 @@
 -4   string      \x00\x00\x00\x00ENDS   Signed Ubiquiti end header, RSA 2048 bit, header size: 264 bytes
 >260 ubelong     !0                     {invalid}
 
+# Ubiquiti additional data
+-4           string   \x00\x00\x00\x00EXEC  Ubiquiti firmware additional data,
+# Non-empty string (16 bytes max)
+>4           byte     0                     {invalid}
+>4           string   x                         name: %s,
+# Size of attached data
+>48          ubelong  x                         size: %d bytes,
+# Size, again
+>52          ubelong  x                         size2: %d bytes,
+# CRC32 of header + data
+>>(48.L+56)  ubelong  x                         CRC32: %x
+# Padding
+>>(48.L+60)  ubelong  !0                    {invalid}
+
 # Found in DIR-100 firmware
 0       string      AIH0        AIH0 firmware header, header size: 48,
 >12     ubelong     0           {invalid}


### PR DESCRIPTION
Ubiquiti firmware images have additional data attached after the Ubiquiti
partition definitions. They are used to convey additional pre-upgrade
information and even firmware signatures (AirOS 6).

Output before commit:
```
DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------
0             0x0             Ubiquiti firmware header, header size: 264 bytes, ~CRC32: 0x84031317, version: "XM.ar7240.v6.0.4-sign.31631.170908.1605"
268           0x10C           Ubiquiti partition header, header size: 56 bytes, name: "PARTu-boot", base address: 0x9F000000, data size: 219336 bytes
140596        0x22534         U-Boot version string, "U-Boot 1.1.4.2-s1031 (May  4 2017 - 15:26:57)"
140788        0x225F4         CRC32 polynomial table, big endian
161048        0x27518         Ubiquiti firmware header, header size: 264 bytes, ~CRC32: 0x65746831, version: " APP Magic mismatch, addr=%x, magic=%x "
212196        0x33CE4         CRC32 polynomial table, big endian
219668        0x35A14         Ubiquiti partition header, header size: 56 bytes, name: "PARTkernel", base address: 0x9F050000, data size: 1010094 bytes
219724        0x35A4C         uImage header, header size: 64 bytes, header CRC: 0x38858DD9, created: 2017-09-08 13:06:25, image size: 1010030 bytes, Data Address: 0x80002000, Entry Point: 0x80002000, data CRC: 0xF3B935F2, OS: Linux, CPU: MIPS, image type: OS Kernel Image, compression type: lzma, image name: "MIPS Ubiquiti Linux-2.6.32.71"
219788        0x35A8C         LZMA compressed data, properties: 0x5D, dictionary size: 8388608 bytes, uncompressed size: 2939492 bytes
1229826       0x12C402        Ubiquiti partition header, header size: 56 bytes, name: "PARTrootfs", base address: 0x9F150000, data size: 6160384 bytes
1229882       0x12C43A        Squashfs filesystem, little endian, version 4.0, compression:lzma, size: 5979019 bytes, 1377 inodes, blocksize: 131072 bytes, created: 2017-09-08 13:06:28
7390330       0x70C47A        gzip compressed data, from Unix, last modified: 2017-09-08 13:04:48
7425150       0x714C7E        gzip compressed data, from Unix, last modified: 2017-05-22 12:00:25
7425447       0x714DA7        Ubiquiti end header, header size: 12 bytes, cumulative ~CRC32: 0x836664BB
```

Output with commit applied:
```
DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------
0             0x0             Ubiquiti firmware header, header size: 264 bytes, ~CRC32: 0x84031317, version: "XM.ar7240.v6.0.4-sign.31631.170908.1605"
268           0x10C           Ubiquiti partition header, header size: 56 bytes, name: "PARTu-boot", base address: 0x9F000000, data size: 219336 bytes
140596        0x22534         U-Boot version string, "U-Boot 1.1.4.2-s1031 (May  4 2017 - 15:26:57)"
140788        0x225F4         CRC32 polynomial table, big endian
161048        0x27518         Ubiquiti firmware header, header size: 264 bytes, ~CRC32: 0x65746831, version: " APP Magic mismatch, addr=%x, magic=%x "
212196        0x33CE4         CRC32 polynomial table, big endian
219668        0x35A14         Ubiquiti partition header, header size: 56 bytes, name: "PARTkernel", base address: 0x9F050000, data size: 1010094 bytes
219724        0x35A4C         uImage header, header size: 64 bytes, header CRC: 0x38858DD9, created: 2017-09-08 13:06:25, image size: 1010030 bytes, Data Address: 0x80002000, Entry Point: 0x80002000, data CRC: 0xF3B935F2, OS: Linux, CPU: MIPS, image type: OS Kernel Image, compression type: lzma, image name: "MIPS Ubiquiti Linux-2.6.32.71"
219788        0x35A8C         LZMA compressed data, properties: 0x5D, dictionary size: 8388608 bytes, uncompressed size: 2939492 bytes
1229826       0x12C402        Ubiquiti partition header, header size: 56 bytes, name: "PARTrootfs", base address: 0x9F150000, data size: 6160384 bytes
1229882       0x12C43A        Squashfs filesystem, little endian, version 4.0, compression:lzma, size: 5979019 bytes, 1377 inodes, blocksize: 131072 bytes, created: 2017-09-08 13:06:28
7390274       0x70C442        Ubiquiti firmware additional data, name: script, size: 34756 bytes, size2: 34756 bytes, CRC32: 7d3e94c5
7390330       0x70C47A        gzip compressed data, from Unix, last modified: 2017-09-08 13:04:48
7425094       0x714C46        Ubiquiti firmware additional data, name: signtr, size: 289 bytes, size2: 289 bytes, CRC32: 1900d2df
7425150       0x714C7E        gzip compressed data, from Unix, last modified: 2017-05-22 12:00:25
7425447       0x714DA7        Ubiquiti end header, header size: 12 bytes, cumulative ~CRC32: 0x836664BB
```
Test files:
https://dl.ubnt.com/firmwares/XW-fw/v6.1.12/XW.v6.1.12.33003.190523.1253.bin
https://dl.ubnt.com/firmwares/XN-fw/v5.6.15/XM.v5.6.15.30572.170328.1107.bin