### PR TITLE
fix getting user's home dir

### DIFF
--- a/src/binwalk/core/settings.py
+++ b/src/binwalk/core/settings.py
@@ -132,6 +132,8 @@ class Settings(object):
                 user_dir = os.getenv(envname)
                 if user_dir is not None:
                     return user_dir
+            if os.path.expanduser("~") is Not None:
+                return os.path.expanduser("~")
         except KeyboardInterrupt as e:
             raise e
         except Exception:


### PR DESCRIPTION
When running binwalk in non-interactive session some environment variables may not be set. This causes binwalk to fail to correctly determine user's home directory. This commit fixes that (at least for linux systems).

It should be also tested on Windows systems.