### PR TITLE
add UNIQUE_PATH_DELIMITER to mount command

### DIFF
--- a/src/binwalk/config/extract.conf
+++ b/src/binwalk/config/extract.conf
@@ -69,10 +69,10 @@
 ^linux ext:ext:tsk_recover -i raw -f ext -a -v '%e' '%%ext-root%%':0:False
 
 # Try mounting the file system (this requires root privileges)
-^squashfs filesystem:squashfs:mkdir squashfs-root && mount -t squashfs '%e' squashfs-root:0:False
-^cramfs filesystem:cramfs:mkdir cramfs-root && mount -t cramfs '%e' cramfs-root:0:False
-^linux ext filesystem:ext2:mkdir ext-root && mount '%e' ext-root:0:False
-^romfs filesystem:romfs:mkdir romfs-root && mount -t romfs '%e' romfs-root:0:False
+^squashfs filesystem:squashfs:mkdir '%%squashfs-root%%' && mount -t squashfs '%e' squashfs-root:0:False
+^cramfs filesystem:cramfs:mkdir '%%cramfs-root%%' && mount -t cramfs '%e' cramfs-root:0:False
+^linux ext filesystem:ext2:mkdir '%%ext-root%%' && mount '%e' ext-root:0:False
+^romfs filesystem:romfs:mkdir '%%romfs-root%%' && mount -t romfs '%e' romfs-root:0:False
 
 # Use sviehb's jefferson.py tool for JFFS2 extraction
 ^jffs2 filesystem:jffs2:jefferson -d '%%jffs2-root%%' '%e':0:False


### PR DESCRIPTION
when extract  firmware with two same filesytem type , they will be mount at same directory and cause error. So we need add UNIQUE_PATH_DELIMITER to mount point.
