### PR TITLE
Improve help output for --dd

### DIFF
--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -59,9 +59,10 @@ class Extractor(Module):
         Option(short='D',
                long='dd',
                type=list,
-               dtype='type:ext:cmd',
+               dtype='type[:ext[:cmd]]',
                kwargs={'manual_rules': [], 'enabled': True},
-               description='Extract <type> signatures, give the files an extension of <ext>, and execute <cmd>'),
+               description='Extract <type> signatures (regular expression), give the files an extension of <ext>, '
+                           'and execute <cmd>'),
         Option(short='M',
                long='matryoshka',
                kwargs={'matryoshka': 8},


### PR DESCRIPTION
Make it clear that ext/cmd are optional and that the type can be a regular
expression.