### PR TITLE
travis: Update Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python:
  - "2.7"
- - "3.3"
  - "3.4"
  - "3.5"
  - "3.6"
+ - "3.7"
+ - "3.8"
  - "nightly"
  - "pypy"
  - "pypy3"


### PR DESCRIPTION
Drop Python 3.3 which isn't available anymore, add python 3.7 and 3.8 instead.