### PR TITLE
Add a plugin for calling "vmlinux-to-elf" from binwalk

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,6 +106,13 @@ $ (cd ubi_reader && sudo python setup.py install)
 ```
 
 ```bash
+# Install vmlinux-to-elf to convert raw Linux kernel in analyzable
+# .ELF files with symbols
+$ sudo apt-get install python3-pip
+$ sudo pip3 install --upgrade git+https://github.com/marin-m/vmlinux-to-elf
+```
+
+```bash
 # Install yaffshiv to extract YAFFS file systems
 $ git clone https://github.com/devttys0/yaffshiv
 $ (cd yaffshiv && sudo python setup.py install)

--- a/deps.sh
+++ b/deps.sh
@@ -71,6 +71,14 @@ function install_yaffshiv
     $SUDO rm -rf yaffshiv
 }
 
+function install_vmlinux_to_elf {
+    find_path python3 # This is Python 3-only, and will install a binary in /usr/local/bin
+    if [ $? -eq 0 ]
+    then
+        $SUDO pip3 install --upgrade git+https://github.com/marin-m/vmlinux-to-elf
+    fi
+}
+
 function install_sasquatch
 {
     git clone https://github.com/devttys0/sasquatch
@@ -254,6 +262,7 @@ if [ $? -ne 0 ]
 fi
 install_pip_package matplotlib
 install_pip_package capstone
+install_vmlinux_to_elf
 install_sasquatch
 install_yaffshiv
 install_jefferson

--- a/src/binwalk/magic/linux
+++ b/src/binwalk/magic/linux
@@ -11,9 +11,21 @@
 # Finds and prints Linux kernel strings in raw Linux kernels (output like uname -a).
 # Commonly found in decompressed embedded kernel binaries.
 0       string      Linux\x20version\x20    Linux kernel version
->14     byte        >0x33                   {invalid}
+>14     byte        >0x36                   {invalid}
 >14     byte        <0x32                   {invalid}
 >14     string      x                       %.6s
+
+# Find and print the Linux kernel symbol table compression
+# dictionary ("kallsyms_token_table").
+# This table contains 256 characters or string fragments:
+# for positions that correspond to an ASCII code points
+# contained in any symbol name, it is the character itself,
+# while other positions correspond to string fragments.
+# As such, ASCII characters [0-9] (that we are looking for)
+# are always present, but never followed by a ":" (the next
+# ASCII codepoint) because it is contained in no symbol name.
+0       string      \x000\x001\x002\x003\x004\x005\x006\x007\x008\x009      Linux kernel embedded symbol table compression dictionary (kallsyms_token_table)
+>21     byte        0x3a        {invalid}
 
 # Linux ARM compressed kernel image
 # Starts with 8 NOPs, with 0x016F2818 at offset 0x24

--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -258,9 +258,12 @@ class Extractor(Module):
                         self.output[r.file.path].extracted[r.offset].files.append(file_path)
 
                     # If recursion was specified, and the file is not the same
-                    # one we just dd'd
+                    # one we just dd'd.
+                    # Also avoid excessive recursion through the fils created by
+                    # the "vmlinuxtoelf.py" plugin
                     if (self.matryoshka and
                         file_path != dd_file_path and
+                        '_reconstructed' not in file_path and
                         scan_extracted_files and
                             self.directory in real_file_path):
                         # If the recursion level of this file is less than or

--- a/src/binwalk/plugins/vmlinuxtoelf.py
+++ b/src/binwalk/plugins/vmlinuxtoelf.py
@@ -1,0 +1,56 @@
+import struct
+import binascii
+import binwalk.core.plugin
+import binwalk.core.compat
+import os
+import os.path
+import subprocess
+
+
+class VMLinuxToElfPlugin(binwalk.core.plugin.Plugin):
+
+    '''
+    This plugin allows to call "vmlinux-to-elf" on the whole
+    file rather than just from some offset of the symbol
+    table that was detected.    
+    '''
+    MODULES = ['Signature']
+    current_file = None
+
+
+    def init(self):
+        
+        if self.module.extractor.enabled:
+            self.module.extractor.add_rule(txtrule=None,
+                                           regex="^linux kernel embedded symbol table",
+                                           extension="kallsyms",
+                                           cmd=self.extractor,
+                                           prepend=True)
+
+
+    def extractor(self, fname):
+        fname = os.path.abspath(fname)
+        outfile = os.path.splitext(fname)[0] + '_reconstructed.elf'
+        fperr = open(os.devnull, "rb")
+        
+        # Remove the automatically dd'd file which is unuseful
+        os.unlink(fname)
+
+        try:
+            subprocess.call(['vmlinux-to-elf', self.original_file_path, outfile], stdout = fperr,  stderr =  fperr)
+        except KeyboardInterrupt as e:
+            raise e
+        except Exception as e:
+            return False
+
+        return True
+
+
+    def scan(self, result):
+        if result.file and result.description.lower().startswith('linux kernel embedded symbol table'):
+            self.original_file_path = result.file.path
+            
+            
+
+
+


### PR DESCRIPTION
Hello,

I have created the following tool: https://github.com/marin-m/vmlinux-to-elf whose the principle is to extract the embedded symbols tables of the linux kernel ([kallsyms.c](https://github.com/torvalds/linux/blob/master/scripts/kallsyms.c)), and to leverage it to reconstruct a fully analyzable .ELF kernel with reconstructed symbol table, along with inferred entry point, architecture and base address, from an arbitrary raw/blob or compresses kernel.

You can refer to the [README.md](https://github.com/marin-m/vmlinux-to-elf#readme) file of the project for a thorough description.

The tool seems to work pretty well so far (I have tested it over a corpus of 45 kernels of 8 different architectures) and I think that being able to obtain an analyzable binary with original function symbol name is something that could be pretty useful to much people, this is why I think it could be useful to integrate it from a binwalk plugin.

I have written a basic pull request that adds the tool as a `pip` dependency and calls it whenever a kernel symbol table seems to be present (on the whole input file as it needs to to work). It also adds a signature from the most recognizable pattern from the kernel embedded symbol table. What do you think about it?

Regards,