### PR TITLE
Stop testing on unsupported Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
  - "2.7"
- - "3.3"
  - "3.4"
  - "3.5"
  - "3.6"


### PR DESCRIPTION
Python 3.3 is no longer supported, so remove it from the CI matrix to make builds green again.