### PR TITLE
Improve D-Link eCos RomFS support and add D-link MD5 based langpack signature

### DIFF
--- a/src/binwalk/magic/filesystems
+++ b/src/binwalk/magic/filesystems
@@ -571,14 +571,17 @@
 
 # Not to be confused with an actual romfs image!
 # ftp://ftp.dlink.eu/Products/dir/dir-600/driver_software/DIR-600_fw_revC1_3-05B15__all_en_20120216.zip
+# based on eCos romfs, but with lzma files compression
 0x10    string          ROMFS\x20v      D-Link ROMFS filesystem,
 >0x17   string          x               version %s,
 >0      string          !\x2EmoR
 >>0     string          !Rom\x2E        {invalid} unknown endianness
 >0      string          \x2EmoR         little endian,
+>>4     lelong          x               %d entries,
 >>8     lelong          x               size: <= %d
 #>>8     lelong-0x20     x               {jump:%d}
 >0      string          Rom\x2E         big endian,
+>>4     belong          x               %d entries,
 >>8     belong          x               size: <= %d
 #>>8     belong-0x20     x               {jump:%d}
 

--- a/src/binwalk/magic/misc
+++ b/src/binwalk/magic/misc
@@ -83,3 +83,10 @@
 # Xilinx FPGA Bitstream
 # Ref: http://www.xilinx.com/support/answers/7891.html
 0       ubequad        0xffffffffaa995566  Xilinx Virtex/Spartan FPGA bitstream dummy + sync word
+
+# D-Link MD5 hash based langpack (sealpac.slp used in embedded PHP i18n function)
+0       belong          0x05ea19ac      D-Link MD5 based langpack (sealpac),
+>4      belong          x               %d translations,
+>8      bequad          !0              {invalid} non-zero header padding
+>0x1f   byte            0
+>>0x10  string          x               langcode: %s


### PR DESCRIPTION
These changes are result of my project with D-Link GO-RT-N150 rev B1
More details about it: https://github.com/syschmod/dlink_patch_utils/wiki/D-Link-GO-RT-N150---vulnerabilities-and-firmware-modification

A paragraph about RomFS structure: https://github.com/syschmod/dlink_patch_utils/wiki/D-Link-GO-RT-N150---vulnerabilities-and-firmware-modification#romfs-structure

A paragraph about langpack structure: https://github.com/syschmod/dlink_patch_utils/wiki/D-Link-GO-RT-N150---vulnerabilities-and-firmware-modification#langpack-vulnerable