### PR TITLE
Improves speed of entropy scan

### DIFF
--- a/src/binwalk/modules/entropy.py
+++ b/src/binwalk/modules/entropy.py
@@ -240,7 +240,6 @@ class Entropy(Module):
         if data:
             data = data.encode('latin-1')
             length = len(data)
-            # seen = dict(((chr(x), 0) for x in range(0, 256)))
             seen = [0] * 256
             for byte in data:
                 seen[byte] += 1


### PR DESCRIPTION
Improved speed of entropy scan by using a list rather than a dictionary for seen values
Optional: vastly improved speed with numpy/numba implementation

The implementation detects whether numpy/numba are installed and automatically leverages them.

The speed improvements are fairly substantial. I generated a 2GB file of random data to benchmark the different implementations. Tests performed on an i5-6500 (dual core/ four thread) with an HDD and measured with `time binwalk -E -N <file>`

| Implementation             | Time (real) |  Time (user) | Time (sys) |
|----------------------------|--------------|-------|--------|
| Original Binwalk           | 3m16.936     | 3m8.363     | 0m1.252     |
| Improved Implementation    | 2m32.586     | 2m23.660    | 0m1.182     |
| Numpy Implementation       | 0m15.702     | 0m9.713     | 0m1.351     |
| Numpy/Numba Implementation | 0m13.257     | 0m5.531     | 0m3.201    |

These numbers include flushing the system cache every run. When the file is cached the Numpy/Numba implementation takes about 6 seconds so a faster disk should result in even better performance