### PR TITLE
moved entropy legend

### DIFF
--- a/src/binwalk/modules/entropy.py
+++ b/src/binwalk/modules/entropy.py
@@ -308,11 +308,11 @@ class Entropy(Module):
 
                 ax.plot([offset, offset], [0, 1.1], '%s-' % color, lw=2, label=description)
 
-            ax.legend(loc='lower right', shadow=True)
+            ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
 
         if self.save_plot:
             self.output_file = os.path.join(os.getcwd(), os.path.basename(fname)) + '.png'
-            fig.savefig(self.output_file)
+            fig.savefig(self.output_file, bbox_inches='tight')
         else:
             plt.show()
 


### PR DESCRIPTION
The entropy graph can be severely broken when used together with the `--signature` option (e.g. `binwalk -BEJ`).
In cases where many signatures hit, the legend can cover the whole plot:
![binwalk_kaputt](https://user-images.githubusercontent.com/9843800/87946068-d9bfea00-caa1-11ea-8749-302cea600acf.png)

This fix moves the legend to the right of the plot. This should ensure there is no overlap:
![binwalk](https://user-images.githubusercontent.com/9843800/87946363-328f8280-caa2-11ea-87a0-13fa2c3af516.png)
