### PR TITLE
Adding power support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ python:
  - "3.7"
  - "3.8"
  - "nightly"
- - "pypy"
- - "pypy3"
 install:
  - pip install coverage
  - pip install backports.lzma

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
-arch: ppc64le
+arch: 
+ - ppc64le
+ - amd64
 python:
  - "2.7"
  - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+arch: ppc64le
 python:
  - "2.7"
  - "3.4"


### PR DESCRIPTION
Adding power support ppc64le

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
The Python Versions=pypy/pypy3 are not available for download and hence excluded from the travis.yml & the build is enabled for other versions of python.
Please refer below link which suggests the build is enabled for both arch: ppc64le/amd64.
https://travis-ci.com/github/santosh653/binwalk