### PR TITLE
Autel EVO firmware magic support

### DIFF
--- a/src/binwalk/magic/firmware
+++ b/src/binwalk/magic/firmware
@@ -976,3 +976,16 @@
 >31    byte      2              compression type: bzip2,
 >31    byte      3              compression type: lzma,
 >32    string    x              image name: "%s"
+
+# AUTEL EVO I/II
+# https://github.com/anthok/autel
+0 string "<filetransfer>" Autel EVO Upgrade Transfer{overlap},
+>16 string "<fileinfo>"
+>28 belong x filename_size: {strlen:%d}%d,
+>32 belong x 
+>36 string x filename: {string}%s,
+>(28.L+36) string "<filecontent>"
+>(28.L+36+15) belong x file_size: %d,
+>(28.L+36+15+4) belong x 
+
+


### PR DESCRIPTION
This PR adds support for Autel EVO I/II firmware magic detection. Currently this only adds the magic detection piece and not extraction.

Sample firmware files can be found on the bottom of Autel's download website.
EVO I: https://auteldrones.com/pages/evo-downloads
EVO II: https://auteldrones.com/pages/evo-ii-downloads
