### PR TITLE
show default_exception_vsr addr for eCos

### DIFF
--- a/src/binwalk/magic/ecos
+++ b/src/binwalk/magic/ecos
@@ -28,6 +28,44 @@
 >8      uleshort    x                                                   exception vector table base address: 0x%.4X
 >12     uleshort    x                                                   \b%.4X
 
+# eCos vector table initialization handlers
+#
+# la	$v0,__default_exception_vsr
+# la	$v1, hal_vsr_table
+# sw	$v0, 0($v1)
+# sw	$v0, 1*4($v1)
+# sw	$v0, 2*4($v1)
+# sw	$v0, 3*4($v1)
+# sw	$v0, 4*4($v1)
+# sw	$v0, 5*4($v1)
+# sw	$v0, 6*4($v1)
+# sw	$v0, 7*4($v1)
+# sw	$v0, 8*4($v1)
+# sw	$v0, 9*4($v1)
+# sw	$v0, 10*4($v1)
+# ...
+
+2       uleshort    0x3C02                                              eCos vector table initialization handler, architecture: MIPSEL,
+>6      uleshort    !0x2442                                             {invalid}
+>10     uleshort    !0x3C03                                             {invalid}
+>14     uleshort    !0x2463                                             {invalid}
+>16     ulelong     !0xAC620004                                         {invalid}
+>20     ulelong     !0xAC620008                                         {invalid}
+>24     ulelong     !0xAC62000C                                         {invalid}
+>28     ulelong     !0xAC620010                                         {invalid}
+>32     ulelong     !0xAC620014                                         {invalid}
+>36     ulelong     !0xAC620018                                         {invalid}
+>40     ulelong     !0xAC62001C                                         {invalid}
+>44     ulelong     !0xAC620020                                         {invalid}
+>48     ulelong     !0xAC620024                                         {invalid}
+>52     ulelong     !0xAC620028                                         {invalid}
+>56     ulelong     !0xAC62002C                                         {invalid}
+>60     ulelong     !0xAC620030                                         {invalid}
+>0      uleshort    x                                                   default exception vector table base address: 0x%.4X
+>4      uleshort    x                                                   \b%.4X,
+>8      uleshort    x                                                   hal_vsr_table base address: 0x%.4X
+>12     uleshort    x                                                   \b%.4X
+
 0       string      \x40\x1A\x68\x00\x00\x00\x00\x00\x33\x5A\x00\x7F    eCos kernel exception handler, architecture: MIPS,
 >12     beshort     !0x3C1B                                             {invalid}
 >16     beshort     !0x277B                                             {invalid}


### PR DESCRIPTION
Add another magic to try to get default_exception_vsr address in eCos firmware (mipsel), for this address may be helpful for locating the base_addr.

Currently, the eCos magic will try to match the following code in the firmware. 
```assembly
rom:80040000 rom_entry:
rom:80040000                 mfc0    $k0, Cause       # Cause of last exception
rom:80040004                 nop
rom:80040008                 andi    $k0, 0x7F
rom:8004000C                 li      $k1, 0x80000200
rom:80040014                 add     $k1, $k0
rom:80040018                 lw      $k1, 0($k1)
rom:8004001C                 jr      $k1
rom:80040020                 nop
```
In my recent analysis on an eCos mipsel firmware. I need to figure out the load base_addr of the firmware. The address `0x80000200` shown above is not really helpful. Finally I used a small trick to figure out the base_addr (`0x80040000`).

When I looked the firmware again, there is a code snippet (maybe) related to `hal_mon_init`. As we can see, the address of `__default_exception_vsr` is `0x80040224`. From my perspective, it's helpful for locating the base_addr. (Page Align: `0x80040224 & ~((1<<12)-1) = 0x80040000`)
```assembly
rom:80040118                 li      $gp, 0x809A1140
rom:80040120                 li      $a0, 0x8099B7D0
rom:80040128                 move    $sp, $a0
rom:8004012C                 li      $v0, loc_80040224     <=== __default_exception_vsr
rom:80040134                 li      $v1, 0x80000200       <=== hal_vsr_table
rom:8004013C                 sw      $v0, 4($v1)
rom:80040140                 sw      $v0, 8($v1)
rom:80040144                 sw      $v0, 0xC($v1)
rom:80040148                 sw      $v0, 0x10($v1)
rom:8004014C                 sw      $v0, 0x14($v1)
rom:80040150                 sw      $v0, 0x18($v1)
rom:80040154                 sw      $v0, 0x1C($v1)
rom:80040158                 sw      $v0, 0x20($v1)
rom:8004015C                 sw      $v0, 0x24($v1)
rom:80040160                 sw      $v0, 0x28($v1)
rom:80040164                 sw      $v0, 0x2C($v1)
```
So I add this magic to match it. In addition, I manually test against 10 eCos firmwares approximately, and all work well. By the way, all the eCos firmwares I find are mipsel endian, so only add the little endian magic.
```shell
$ binwalk RGS200-12P.bin 

DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------
0             0x0             eCos kernel exception handler, architecture: MIPSEL, exception vector table base address: 0x80000200
128           0x80            eCos kernel exception handler, architecture: MIPSEL, exception vector table base address: 0x80000200
300           0x12C           eCos vector table initialization handler, architecture: MIPSEL, default exception vector table base address: 0x80040224, hal_vsr_table base address: 0x80000200
# ...
```

