### PR TITLE
Fix: binwalk stuck when extract encrypt zip files

### DIFF
--- a/src/binwalk/config/extract.conf
+++ b/src/binwalk/config/extract.conf
@@ -52,7 +52,7 @@
 # 7z handles most zip files, but fails on some zip archives, inexplicably seeing
 # only the *last* entry in the zip archive (though 7z thinks it succeeded). See
 # StarCam firmware CH-sys-48.53.64.67.zip.
-^zip archive data:zip:unzip -o '%e':0
+^zip archive data:zip:unzip -P '' -o '%e':0
 ^zip archive data:zip:jar xvf '%e':0
 ^zip archive data:zip:7z x -y '%e' -p '':0,1
 


### PR DESCRIPTION
Call 'unzip' with empty password, to avoid 'unzip' stuck in interactive mode when process encrypt files