### PR TITLE
Fix size from 128Kbit to 256Kbit for Game Boy RAM type 3

### DIFF
--- a/src/binwalk/magic/console
+++ b/src/binwalk/magic/console
@@ -48,7 +48,7 @@
 
 >0x149  byte        1               \b, RAM: 16Kbit
 >0x149  byte        2               \b, RAM: 64Kbit
->0x149  byte        3               \b, RAM: 128Kbit
+>0x149  byte        3               \b, RAM: 256Kbit
 >0x149  byte        4               \b, RAM: 1Mbit
 
 #>0x14e  long        x               \b, CRC: %x


### PR DESCRIPTION
See file/file@ca3a059b4ca56c99a882fd6d85798cf4aeccf2ff and https://bugs.astron.com/view.php?id=233