### PR TITLE
Making entropy work with python3

### DIFF
--- a/src/binwalk/modules/entropy.py
+++ b/src/binwalk/modules/entropy.py
@@ -7,11 +7,8 @@ import zlib
 import binwalk.core.common
 from binwalk.core.compat import *
 from binwalk.core.module import Module, Option, Kwarg
+import numpy as np
 
-#try:
-#    import numpy as np
-#except ImportError:
-#    pass
 try:
     from numba import njit
 except ImportError:
@@ -253,7 +250,7 @@ class Entropy(Module):
 
     def shannon_numpy(self, data):
         if data:
-            return self._shannon_numpy(bytes2str(data))
+            return self._shannon_numpy(data.encode('utf-8'))
         else:
             return 0
     

--- a/src/binwalk/modules/entropy.py
+++ b/src/binwalk/modules/entropy.py
@@ -250,7 +250,7 @@ class Entropy(Module):
 
     def shannon_numpy(self, data):
         if data:
-            return self._shannon_numpy(data.encode('utf-8'))
+            return self._shannon_numpy(data.encode('latin-1'))
         else:
             return 0
     


### PR DESCRIPTION
Firstly, importing `numpy` is necessary (see #543) for binwalk to be able to draw a graph.

Secondly, using `bytes2str` doesn't work with python3 (v3.9), since it returns an object with the type `unicode_type` (a type recognized by `numba`), and there is no overload for `np.frombuffer(unicode_type, dtype)`. So, we need to convert `data` to a UTF-8 string before passing it to the `_shannon_numpy` function. This way, no exceptions or errors are thrown.

This fixes #543. Tested on *Kali 2021.1* and *Python3.9.2*.