### PR TITLE
Update binida.py

### DIFF
--- a/src/scripts/binida.py
+++ b/src/scripts/binida.py
@@ -1,3 +1,4 @@
+import idaapi
 if idaapi.IDA_SDK_VERSION <= 695:
     import idc
     import idaapi


### PR DESCRIPTION
In IDA 7.6 I get "NameError: name 'idaapi' is not defined"
Adding "import idaapi" at the start solves it.