### PR TITLE
Add firmware signatures used with JBOOT bootloader

### DIFF
--- a/src/binwalk/magic/firmware
+++ b/src/binwalk/magic/firmware
@@ -988,4 +988,64 @@
 >(28.L+36+15) belong x file_size: %d,
 >(28.L+36+15+4) belong x 
 
+# ARM update header (used with JBOOT bootloader)
+# More info in file: https://github.com/openwrt/openwrt/blob/master/tools/firmware-utils/src/mkdlinkfw.c
+0    regex    [A-Z]{3}[A-Z0-9]{9}.{52}\x42\x48  ARM update header (used with JBOOT),
+>0   string   DLK                               vendor: D-Link,
+>0   string   LVA                               vendor: Lava,
+>0   string   ZXL                               vendor: Zyxel,
+>0   string   x                                 ROM ID: %s,
+>12  uleshort !0                                {invalid}
+>14  uleshort x                                 header JBOOT checksum: 0x%X,
+>16  ulelong  !0                                {invalid}
+>20  ulelong  !0                                {invalid}
+>24  uleshort !0                                {invalid}
+>26  byte     x                                 lpvs: %d
+>27  byte     x                                 mbz: %d
+>28  ulelong  x                                 timestamp 0x%X,
+>32  ulelong  x                                 erease start: 0x%X,
+>36  ulelong  x                                 erease length: %d bytes,
+>40  ulelong  x                                 data start: 0x%X,
+>44  ulelong  x                                 data length: %d bytes,
+>48  ulelong  !0                                {invalid}
+>52  ulelong  !0                                {invalid}
+>56  ulelong  !0                                {invalid}
+>60  ulelong  !0                                {invalid}
+>64  uleshort !0x4842                           {invalid}
+>66  uleshort >0                                header version: %d,
+>68  uleshort !0                                {invalid}
+>70  byte     x                                 section id: %d,
+>71  byte     x                                 image info type: %d,
+>72  ulelong  x                                 image info address: 0x%X,
+>76  uleshort x                                 family member: 0x%X,
+>78  uleshort x                                 header JBOOT checksum: 0x%X
+
+#Amit JBOOT STAG header
+# More info in file: https://github.com/openwrt/openwrt/blob/master/tools/firmware-utils/src/mkdlinkfw.c
+0   regex    [\x00-\x10\xff][\x00-\x10]\x24\x2b  JBOOT STAG header,
+>1  ubyte    x                                   image id: %d,
+>4  ulelong  x                                   timestamp 0x%X, #TODO
+>8  ulelong  x                                   image size: %d bytes,
+>12 uleshort x                                   image JBOOT checksum: 0x%X,
+>14 uleshort x                                   header JBOOT checksum: 0x%X
+
+#Amit JBOOT SCH2 header
+# More info in file: https://github.com/openwrt/openwrt/blob/master/tools/firmware-utils/src/mkdlinkfw.c
+0   regex    \x24\x21[\x00-\x03]\x02  JBOOT SCH2 kernel header,
+>2  ubyte    >3                       {invalid}
+>2  ubyte    0                        compression type: none,
+>2  ubyte    1                        compression type: jz,
+>2  ubyte    2                        compression type: gzip,
+>2  ubyte    3                        compression type: lzma,
+>4  ulelong  x                        Entry Point: 0x%X,
+>8  ulelong  x                        image size: %d bytes,
+>12 ulelong  x                        data CRC: 0x%X,
+>16 ulelong  x                        Data Address: 0x%X,
+>20 ulelong  x                        rootfs offset: 0x%X,
+>24 ulelong  x                        rootfs size: %d bytes,
+>28 ulelong  x                        rootfs CRC: 0x%X,
+>32 ulelong  x                        header CRC: 0x%X,
+>36 uleshort >0x27                    {size:%d} header size: %d bytes,
+>36 uleshort <0x28                    {invalid}
+>38 uleshort x                        cmd line length: %d bytes
 


### PR DESCRIPTION
JBOOT is closed source bootloader developed by Amit and used by at
least in D-Link, Zyxel and Lava routers. Mostly is used with mt7620
processors.

More info can be found at:
https://github.com/openwrt/openwrt/blob/master/tools/firmware-utils/src/mkdlinkfw.c


Some examples:


D-Link DWR-118 flash dump:
```
DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------
8404          0x20D4          LZMA compressed data, properties: 0x5D, dictionary size: 8388608 bytes, uncompressed size: 90640 bytes
65536         0x10000         JBOOT STAG header, image id: 4, timestamp 0x840E932, image size: 1433270 bytes, image JBOOT checksum: 0xF9B7, header JBOOT checksum: 0x6E1
65552         0x10010         JBOOT SCH2 kernel header, compression type: lzma, Entry Point: 0x80000000, image size: 1433230 bytes, data CRC: 0x8A9A4005, Data Address: 0x80000000, rootfs offset: 0xBC180000, rootfs size: 6021120 bytes, rootfs CRC: 0xA4F19C71, header CRC: 0xA4791B1C, header size: 40 bytes, cmd line length: 0 bytes
65592         0x10038         LZMA compressed data, properties: 0x5D, dictionary size: 33554432 bytes, uncompressed size: 4208384 bytes
1572864       0x180000        Squashfs filesystem, little endian, version 4.0, compression:gzip, size: 6017560 bytes, 1308 inodes, blocksize: 131072 bytes, created: 2015-09-25 09:28:40
15794176      0xF10000        JBOOT STAG header, image id: 5, timestamp 0x8447E0A, image size: 819200 bytes, image JBOOT checksum: 0xD8DE, header JBOOT checksum: 0xF09C
15794192      0xF10010        Squashfs filesystem, little endian, version 4.0, compression:gzip, size: 816240 bytes, 199 inodes, blocksize: 131072 bytes, created: 2015-10-06 06:16:11
16711680      0xFF0000        JBOOT STAG header, image id: 7, timestamp 0x50, image size: 1442 bytes, image JBOOT checksum: 0xDF2F, header JBOOT checksum: 0xE8B2
16711744      0xFF0040        Zlib compressed data, default compression
16769024      0xFFE000        JBOOT STAG header, image id: 2, timestamp 0x85D89DC, image size: 1168 bytes, image JBOOT checksum: 0xFFFF, header JBOOT checksum: 0x3C10
``` 

OpenWrt D-Link DWR-960 factory image:
```
DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------
0             0x0             ARM update header (used with JBOOT), vendor: D-Link, ROM ID: DLK6E2429001, header JBOOT checksum: 0xD205, lpvs: 1 mbz: 0 timestamp 0xB0B4F06, erease start: 0x10000, erease length: 16646144 bytes, data start: 0x10000, data length: 5505028 bytes, header version: 2, section id: 4, image info type: 4, image info address: 0x0, family member: 0x6E24, header JBOOT checksum: 0xCFB0
80            0x50            JBOOT STAG header, image id: 4, timestamp 0xB0B4F06, image size: 1991009 bytes, image JBOOT checksum: 0xBC5C, header JBOOT checksum: 0x58EA
96            0x60            JBOOT SCH2 kernel header, compression type: lzma, Entry Point: 0x80000000, image size: 1990969 bytes, data CRC: 0x727B2B18, Data Address: 0x80000000, rootfs offset: 0x1F6171, rootfs size: 3333398 bytes, rootfs CRC: 0x21CF9FA4, header CRC: 0x166F4ABB, header size: 40 bytes, cmd line length: 0 bytes
136           0x88            LZMA compressed data, properties: 0x6D, dictionary size: 8388608 bytes, uncompressed size: 6215840 bytes
1991105       0x1E61C1        Squashfs filesystem, little endian, version 4.0, compression:xz, size: 3333398 bytes, 1630 inodes, blocksize: 262144 bytes, created: 2021-08-31 22:20:08
```

Zyxel firmware file:
```
DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------
0             0x0             ARM update header (used with JBOOT), vendor: Zyxel, ROM ID: ZXL6E2431001, header JBOOT checksum: 0xC252, lpvs: 1 mbz: 0 timestamp 0x9AD0949, erease start: 0x10000, erease length: 1507328 bytes, data start: 0x10000, data length: 1310936 bytes, header version: 2, section id: 4, image info type: 4, image info address: 0x0, family member: 0x6E24, header JBOOT checksum: 0x19C3
80            0x50            JBOOT STAG header, image id: 4, timestamp 0x9AD0949, image size: 1310920 bytes, image JBOOT checksum: 0xC157, header JBOOT checksum: 0xFBAD
96            0x60            JBOOT SCH2 kernel header, compression type: lzma, Entry Point: 0x80000000, image size: 1310880 bytes, data CRC: 0x835AA6DC, Data Address: 0x80000000, rootfs offset: 0xBC180000, rootfs size: 8900608 bytes, rootfs CRC: 0x9AD2B4EC, header CRC: 0xEB2BFD8E, header size: 40 bytes, cmd line length: 0 bytes
136           0x88            LZMA compressed data, properties: 0x5D, dictionary size: 33554432 bytes, uncompressed size: 3840340 bytes
937300        0xE4D54         JBOOT STAG header, image id: 8, timestamp 0xEF9590C2, image size: 2708135554 bytes, image JBOOT checksum: 0x1B83, header JBOOT checksum: 0xC056
1311016       0x140128        ARM update header (used with JBOOT), vendor: Zyxel, ROM ID: ZXL6E2431001, header JBOOT checksum: 0xDE9A, lpvs: 1 mbz: 0 timestamp 0x9AD0949, erease start: 0x180000, erease length: 13697024 bytes, data start: 0x180000, data length: 8900608 bytes, header version: 2, section id: 8, image info type: 0, image info address: 0x0, family member: 0x6E24, header JBOOT checksum: 0x30F3
1311096       0x140178        Squashfs filesystem, little endian, version 4.0, compression:gzip, size: 8899886 bytes, 1598 inodes, blocksize: 131072 bytes, created: 2018-10-04 04:16:39
10211704      0x9BD178        ARM update header (used with JBOOT), vendor: Zyxel, ROM ID: ZXL6E2431001, header JBOOT checksum: 0xD94B, lpvs: 1 mbz: 0 timestamp 0x9AD0949, erease start: 0xF10000, erease length: 917504 bytes, data start: 0xF10000, data length: 512016 bytes, header version: 2, section id: 5, image info type: 0, image info address: 0x0, family member: 0x6E24, header JBOOT checksum: 0x35C6
10211800      0x9BD1D8        Squashfs filesystem, little endian, version 4.0, compression:gzip, size: 510048 bytes, 251 inodes, blocksize: 131072 bytes, created: 2018-10-04 04:16:38
```

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>