### PR TITLE
Exit unclean when IOError occurs

### DIFF
--- a/src/binwalk/__main__.py
+++ b/src/binwalk/__main__.py
@@ -54,7 +54,7 @@ def main():
         else:
             runme()
     except IOError:
-        pass
+        exit(1)
     except KeyboardInterrupt:
         sys.stdout.write("\n")
 


### PR DESCRIPTION
Related https://github.com/ReFirmLabs/binwalk/issues/571

I ran binwalk in docker and did not create a home directory for the user that I ran binwalk with.
It was very confusing when binwalk worked as root but not as my newly created user.

Using a positive exitcode communicates that something went wrong.