### PR TITLE
Fixed CSV hex column

### DIFF
--- a/src/binwalk/core/display.py
+++ b/src/binwalk/core/display.py
@@ -71,7 +71,8 @@ class Display(object):
         if self.fp:
             if self.csv:
                 try:
-                    self.csv.writerow(columns)
+                    self.csv.writerow(
+                        (columns[0], '%X' % columns[1] if isinstance(columns[1], int) else columns[1], columns[2]))
                 except UnicodeEncodeError:
                     self.csv.writerow(self._fix_unicode_list(columns))
             else:


### PR DESCRIPTION
Hex column in the result tuple is not formatted and is set as decimal in the generated CSV log. This is a quick fix for the issue.
