### PR TITLE
Fix breakage on Windows caused by use of unavailable pwd module

### DIFF
--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -9,7 +9,7 @@ import re
 try:
     import pwd
 except ImportError:
-   pwd = None
+    pwd = None
 
 import stat
 import shlex


### PR DESCRIPTION
Binwalk has been broken on Windows since the commit 0d6bf607c979b51b46f3d13c9e56267ba54688bb due to import of pwd module that is not available on Windows. I have added checks whether pwd module is available or not with os.name variable. pwd module is available if os.name is "posix" (on Linux, FreeBSD, and so on). On Windows, os.name is "nt". This pull request fixes the issues #547 and #562.

The following tests used the latest code of the commit fa0c0bd59b8588814756942fe4cb5452e76c1dcd

Before fix:
```
PS C:\Users\nobut\Desktop> py -3
Python 3.9.8 (tags/v3.9.8:bb3fdcf, Nov  5 2021, 20:48:33) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import binwalk
>>> for module in binwalk.scan("test.png", signature=True, quiet=True, string=False):
...     for result in module.results:
...         print("Offset: 0x%x\t%s" % (result.offset, result.description))
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\nobut\AppData\Local\Programs\Python\Python39\lib\site-packages\binwalk-2.3.3-py3.9.egg\binwalk\__init__.py", line 10, in scan
    objs = m.execute()
  File "C:\Users\nobut\AppData\Local\Programs\Python\Python39\lib\site-packages\binwalk-2.3.3-py3.9.egg\binwalk\core\module.py", line 782, in execute
    for module in self.list():
  File "C:\Users\nobut\AppData\Local\Programs\Python\Python39\lib\site-packages\binwalk-2.3.3-py3.9.egg\binwalk\core\module.py", line 699, in list
    import binwalk.modules
  File "C:\Users\nobut\AppData\Local\Programs\Python\Python39\lib\site-packages\binwalk-2.3.3-py3.9.egg\binwalk\modules\__init__.py", line 16, in <module>
    from binwalk.modules.extractor import Extractor
  File "C:\Users\nobut\AppData\Local\Programs\Python\Python39\lib\site-packages\binwalk-2.3.3-py3.9.egg\binwalk\modules\extractor.py", line 7, in <module>
    import pwd
ModuleNotFoundError: No module named 'pwd'
>>>
```

After fix:
```
PS C:\Users\nobut\Desktop> py -3
Python 3.9.8 (tags/v3.9.8:bb3fdcf, Nov  5 2021, 20:48:33) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import binwalk
>>> for module in binwalk.scan("test.png", signature=True, quiet=True, string=False):
...     for result in module.results:
...         print("Offset: 0x%x\t%s" % (result.offset, result.description))
...
Offset: 0x0     PNG image, 471 x 1062, 8-bit/color RGBA, non-interlaced
Offset: 0x5b    Zlib compressed data, compressed
>>>
```
