### PR TITLE
Use entry_points to allow install as exe in windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -340,11 +340,11 @@ setup(
     package_dir={"": "src"},
     packages=[MODULE_NAME],
     package_data={MODULE_NAME: install_data_files},
-    scripts=[
-        os.path.join(
-            "src",
-            "scripts",
-            SCRIPT_NAME)],
+    entry_points={
+        'console_scripts': [
+            'binwalk = binwalk.__main__:main',
+        ]
+    },
     cmdclass={
         'clean': CleanCommand,
         'uninstall': UninstallCommand,


### PR DESCRIPTION
Windows don't support shebang, so setuptool will build python script into exe on windows if we use entry_points to specify the entry script, please kindly accept this, thanks.