### PR TITLE
call unrar with path extraction and without any interaction

### DIFF
--- a/src/binwalk/config/extract.conf
+++ b/src/binwalk/config/extract.conf
@@ -31,7 +31,7 @@
 ^bzip2 compressed data:bz2:bzip2 -d '%e'
 ^compress'd data:Z:gzip -d '%e'
 ^posix tar archive:tar:tar xvf '%e'
-^rar archive data:rar:unrar e '%e'
+^rar archive data:rar:unrar x -y '%e'
 ^rar archive data:rar:unrar -x '%e' # This is for the 'free' version
 ^arj archive data.*comment header:arj:arj -y e '%e'
 ^lha:lha:lha efi '%e'


### PR DESCRIPTION
This is a fix for #457 - binwalk can hang with rar archives.

binwalk calls unrar with e, which does not extract paths, and without -y, meaning files won't be overwritten. The tool asks the user if it shall overwrite a file, but given it's called from binwalk without interaction it just hangs.

This changes two things:
* use x instead of e to extract paths (so an archive with multiple files with the same name in different subdirectories can be properly extracted)
* Pass -y which will answer "yes" to all questions by the tool

