### PR TITLE
Adds option to generate reproducible results

### DIFF
--- a/src/binwalk/core/display.py
+++ b/src/binwalk/core/display.py
@@ -99,11 +99,15 @@ class Display(object):
 
             if self.csv:
                 self.log("", ["FILE", "MD5SUM", "TIMESTAMP"])
-                self.log("", [file_name, md5sum, timestamp])
+                if self.reproducible:
+                    self.log("", [file_name, md5sum, "REDACTED"])
+                else:
+                    self.log("", [file_name, md5sum, timestamp])
 
             self._fprint("%s", "\n", csv=False)
-            self._fprint("Scan Time:     %s\n", [
-                         timestamp], csv=False, filter=False)
+            if not self.reproducible:
+                self._fprint("Scan Time:     %s\n", [
+                    timestamp], csv=False, filter=False)
             self._fprint("Target File:   %s\n", [
                          file_name], csv=False, filter=False)
             self._fprint(

--- a/src/binwalk/modules/general.py
+++ b/src/binwalk/modules/general.py
@@ -56,6 +56,10 @@ class General(Module):
                short='c',
                kwargs={'csv': True},
                description='Log results to file in CSV format'),
+        Option(long='reproducible',
+               short=None,
+               kwargs={'reproducible': True},
+               description='Display reproducible output'),
         Option(long='term',
                short='t',
                kwargs={'format_to_terminal': True},
@@ -110,6 +114,7 @@ class General(Module):
         Kwarg(name='format_to_terminal', default=False),
         Kwarg(name='quiet', default=False),
         Kwarg(name='verbose', default=False),
+        Kwarg(name='reproducible', default=False),
         Kwarg(name='files', default=[]),
         Kwarg(name='show_help', default=False),
         Kwarg(name='keep_going', default=False),
@@ -143,6 +148,7 @@ class General(Module):
                                                     csv=self.csv,
                                                     quiet=self.quiet,
                                                     verbose=self.verbose,
+                                                    reproducible=self.reproducible,
                                                     fit_to_screen=self.format_to_terminal)
 
         if self.show_help:


### PR DESCRIPTION
While timestamps and scan times are often useful, they result in
outputs that are not reproducible. This change adds an option to
remove/redact timestamps and scan times from stdout and logs.

This change is intended to ensure that binwalk can be used directly in a build system e.g. GNU make while maintaining correctness in caching.