### PR TITLE
Remove unstuff from dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,12 +79,6 @@ $ git clone https://github.com/devttys0/yaffshiv
 $ (cd yaffshiv && sudo python setup.py install)
 ```
 
-```bash
-# Install unstuff (closed source) to extract StuffIt archive files
-$ wget -O - http://downloads.tuxfamily.org/sdtraces/stuffit520.611linux-i386.tar.gz | tar -zxv
-$ sudo cp bin/unstuff /usr/local/bin/
-```
-
 Note that for Debian/Ubuntu users, all of the above dependencies can be installed automatically using the included `deps.sh` script:
 
 ```bash

--- a/deps.sh
+++ b/deps.sh
@@ -95,17 +95,6 @@ function install_jefferson
     $SUDO rm -rf jefferson
 }
 
-function install_unstuff
-{
-    mkdir -p /tmp/unstuff
-    cd /tmp/unstuff
-
-    wget -O - http://downloads.tuxfamily.org/sdtraces/stuffit520.611linux-i386.tar.gz | tar -zxv
-    $SUDO cp bin/unstuff /usr/local/bin/
-    cd -
-    rm -rf /tmp/unstuff
-}
-
 function install_cramfstools
 {
   # Downloads cramfs tools from sourceforge and installs them to $INSTALL_LOCATION
@@ -251,7 +240,6 @@ install_pip_package "setuptools matplotlib capstone pycryptodome gnupg tk"
 install_sasquatch
 install_yaffshiv
 install_jefferson
-install_unstuff
 install_ubireader
 
 if [ $distro_version = "18" ]

--- a/src/binwalk/config/extract.conf
+++ b/src/binwalk/config/extract.conf
@@ -37,7 +37,6 @@
 ^lha:lha:lha efi '%e'
 ^iso 9660:iso:7z x '%e' -oiso-root
 ^microsoft cabinet archive:cab:cabextract '%e'
-^stuffit:sit:unstuff '%e'
 ^osx dmg:dmg:7z x '%e'
 ^lzo compressed data:lzo:lzop -f -d '%e'
 ^intel hex:hex:srec_cat '%e' -Intel -Output '%e.bin' -Binary


### PR DESCRIPTION
Removing support for stuffit archives as they are generally no longer needed.