### PR TITLE
fix path traversal in PFS extractor script

### DIFF
--- a/src/binwalk/plugins/unpfs.py
+++ b/src/binwalk/plugins/unpfs.py
@@ -104,7 +104,7 @@ class PFSExtractor(binwalk.core.plugin.Plugin):
                 data = binwalk.core.common.BlockFile(fname, 'rb')
                 data.seek(fs.get_end_of_meta_data())
                 for entry in fs.entries():
-                    outfile_path = os.path.join(out_dir, entry.fname)
+                    outfile_path = os.path.abspath(os.path.join(out_dir, entry.fname))
                     if not outfile_path.startswith(out_dir):
                         binwalk.core.common.warning("Unpfs extractor detected directory traversal attempt for file: '%s'. Refusing to extract." % outfile_path)
                     else:


### PR DESCRIPTION
`os.path.join` does not fully resolve a path so the condition that follows will never be true. Fixed by resolving the path using `os.path.abspath`.

An attacker could craft a malicious PFS file that would cause binwalk to write outside the extraction directory. I attached a proof-of-concept ([poc.zip](https://github.com/ReFirmLabs/binwalk/files/9873311/poc.zip)) that, when extracted from the user's home directory, would extract a malicious binwalk module in `.config/binwalk/plugins`. This malicious plugin would then be loaded and executed by binwalk, leading to RCE.

---

PoC run:

```
/usr/local/bin/binwalk -M -e /tmp/poc.zip

Scan Time:     2022-10-26 21:50:26
Target File:   /tmp/poc.zip
MD5 Checksum:  4fdad30c7c1b4915938b5ad2786f5bf8
Signatures:    411

DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------
0             0x0             Zip archive data, at least v2.0 to extract, compressed size: 170, uncompressed size: 349, name: malicious.pfs
324           0x144           End of Zip archive, footer length: 22


Scan Time:     2022-10-26 21:50:26
Target File:   /home/quentin/_poc.zip.extracted/malicious.pfs
MD5 Checksum:  9a12bccad3db3ed8b818a31846d5976f
Signatures:    411

DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------
0             0x0             PFS filesystem, version 0.9, 1 files

hello from malicious plugin
hello from malicious plugin
hello from malicious plugin
hello from malicious plugin
```

The malicious plugin is simply this:

```python
import binwalk.core.plugin

class MaliciousExtractor(binwalk.core.plugin.Plugin):
    """
    Malicious binwalk plugin
    """

    def init(self):
        print("hello from malicious plugin")
```

It's triggering four times because I did not define the `MODULES` attribute.