### PR TITLE
Add Microware OS-9/68000 magic support, including validation

### DIFF
--- a/src/binwalk/magic/executables
+++ b/src/binwalk/magic/executables
@@ -487,3 +487,13 @@
 >>8     byte            !0x2F           {invalid}
 >3      string          x               shebang: "%s"
 
+# Microware OS-9/68000 module
+0       string   \x4a\xfc   Microware OS-9/68000 module, 
+>2      beshort  x          Revision: %d,
+>4      belong   x          Size: %d,
+>4      belong   x          {size:%d}
+>4      belong   x          {jump:%d}
+>8      beshort  x          Group ID: %d,
+>10     beshort  x          User ID: %d,
+>(12.L) string   x          Name: %s
+>(12.L) string   x          {name:%s}

--- a/src/binwalk/plugins/os9_68kvalid.py
+++ b/src/binwalk/plugins/os9_68kvalid.py
@@ -1,0 +1,22 @@
+import struct
+
+import binwalk.core.plugin
+
+class MWOS9_68000Validate(binwalk.core.plugin.Plugin):
+    # This module does a header parity check to verify it is a OS-9 module
+    parity = 0
+
+    def _header_parity(self, string):
+        parity = 0
+        shorts = struct.unpack('>'+'H'*24, string)
+        for short in shorts:
+            parity ^= short
+        return ~parity
+    def scan(self, result):
+        if result.description.lower().startswith('microware os-9/68000 module'):
+            fd = self.module.config.open_file(result.file.path, offset=result.offset)
+            words = binwalk.core.compat.str2bytes(fd.read(48))
+            fd.close()
+
+            if self._header_parity(words) & 0xFFFF != 0:
+                result.valid = False


### PR DESCRIPTION
This PR adds support for Microware OS-9/68000 magic support, and validates them by doing a header parity check on the result (ref: Microware OS-9/68k Technical Manual)

Can be tested on, for example, a ROM dump of a Philips CD-i system (publicly available)