### PR TITLE
Improve YAFFS signature

### DIFF
--- a/src/binwalk/magic/filesystems
+++ b/src/binwalk/magic/filesystems
@@ -38,11 +38,50 @@
 #>0x1e   string      minix       \b, bootable
 
 # YAFFS
-0    string     \x03\x00\x00\x00\x01\x00\x00\x00\xFF\xFF\x00\x00    YAFFS filesystem, little endian
-# The big endian signature has to be done a bit differently to prevent it from being self-overlapping
-4    string     \x00\x00\x00\x01\xFF\xFF                            YAFFS filesystem, big endian
->0   string     !\x00\x00\x00\x03                                   {invalid}(first object is not a directory)
->10  string     !\x00                                               {invalid}(unexpected name in the first object entry)
+# The layout itself is undocumented, determined by the memory layout of the 
+# reference implementation. This signature is derived from the
+# reference implementation code and generated test cases
+# We recognize the start of an object header defined by yaffs_obj_hdr:
+# (Note the values being encoded depending on platform endianess)
+
+# u32 type  /* enum yaffs_obj_type, valid 1-5  */
+# u32 parent_obj_id; /* 1 for root objects we recognize */
+# u16 sum_no_longer_used; /* checksum of name. Not used by YAFFS and memset to 0xFF */
+# YCHAR name[YAFFS_MAX_NAME_LENGTH + 1];
+
+# mkyaffsimage always writes a root directory with empty name, then processing the target directory contents
+# mkyaffs2image directly proceeds to writing entries with the appropriate u32 YAFFS_OBJECT_TYPE (1-5 valid), each with parent id 1
+
+#Little Endian: XX 00 00 00 01 00 00 00 FF FF YY
+#XX: 01 - 05 (object type)
+#YY: 00 for version 1 root directory, > 00 for version 2 (name data)
+0x1    string     \x00\x00\x00\x01\x00\x00\x00\xFF\xFF     YAFFS filesystem root entry, little endian,
+>0     ulelong    0                                        {invalid}(unknown type id)
+>0     ulelong    1                                        type file,
+>0     ulelong    2                                        type symlink,
+>0     ulelong    3                                        type root or directory,
+>0     ulelong    4                                        type hardlink,
+>0     ulelong    5                                        type special,
+>0     ulelong    >5                                       {invalid}(invalid type id)
+>0xA   byte       0                                        v1 root directory
+>0xA   byte       !0                                       object entry
+>>0xA  string     x                                        (name: "%s")
+
+#Big Endian: 00 00 00 XX 00 00 00 01 FF FF YY
+#XX: 01 - 05 (object type)
+#YY: 00 for version 1 root directory, > 00 for version 2 (name data)
+0x4     string     \x00\x00\x00\x01\xFF\xFF
+>0      string     \x00\x00\x00                            YAFFS filesystem root entry, big endian,
+>>0     ubelong    0                                       {invalid}(unknown type id)
+>>0     ubelong    1                                       type file,
+>>0     ubelong    2                                       type symlink,
+>>0     ubelong    3                                       type root or directory,
+>>0     ubelong    4                                       type hardlink,
+>>0     ubelong    5                                       type special,
+>>0     ubelong    >5                                      {invalid}(invalid type id)
+>>0xA   byte       0                                       v1 root directory
+>>0xA   byte       !0                                      object entry
+>>>0xA  string     x                                       (name: "%s")
 
 # EFS2 file system - jojo@utulsa.edu
 0      lelong       0x53000000       EFS2 Qualcomm filesystem super block, little endian,


### PR DESCRIPTION
The current, simple YAFFS signature has several flaws, and a regression in not being able to detect yaffs2 images (read: images created with mkyaffs2image tool) since https://github.com/ReFirmLabs/binwalk/commit/46d8a3231d47002cc6d02837d207110858b70cd3.

Therefore, the current signature failed to find valid YAFFS images during tests, both with generated test images and in a real world scientific use-case examining an Android device NAND dump.

Unfortunately, the YAFFS on-disk format is poorly documented and mainly defined by the memory layout of the reference implementation found here: http://www.aleph1.co.uk/gitweb/?p=yaffs2.git;a=blob;f=yaffs_guts.h;h=74ded0be526f1f44c91ce90a6d54cc52bb338cf0;hb=HEAD#l329

I propose the signatures in the attached commit, where we recognize the start of an object header defined by yaffs_obj_hdr, with the values being encoded depending on platform endianess:

```
u32 type  /* enum yaffs_obj_type, valid 1-5  */
u32 parent_obj_id; /* 1 for root objects we recognize */
u16 sum_no_longer_used; /* checksum of name. Not used by YAFFS and memset to 0xFF */
YCHAR name[YAFFS_MAX_NAME_LENGTH + 1];
```

Notes:
- mkyaffsimage always writes a root directory with empty name, then processing the target directory contents.
- mkyaffs2image directly proceeds to writing entries with the appropriate u32 YAFFS_OBJECT_TYPE (1-5 valid), each with parent id

From a test set of 9 images generated with different contents and versions of the reference implementation, the old signature recognized 5, while the improved signature recognized all images and displayed additional data where appropriate (root file name). Attached for reference are the test images, as well as the old and new logs generated when executing binwalk directly on these files.

Various remaining parameters (NAND layout, ECC, etc.) do not seem to have an effect on the object header examined here.
Correct execution could also be verified with the device dump in question.

[binwalk_old.log](https://github.com/ReFirmLabs/binwalk/files/10483305/binwalk_old.log)
[binwalk_new.log](https://github.com/ReFirmLabs/binwalk/files/10483499/binwalk_new.log)
[testimages.tar.gz](https://github.com/ReFirmLabs/binwalk/files/10483429/testimages.tar.gz)



