### PR TITLE
Remove remaining Python 2 compatibility bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ Binwalk is a fast, easy to use tool for analyzing, reverse engineering, and extr
 
 Prior to Binwalk v2.3.3, extracted archives could create symlinks which point anywhere on the file system, potentially resulting in a directory traversal attack if subsequent extraction utilties blindly follow these symlinks. More generically, Binwalk makes use of many third-party extraction utilties which may have unpatched security issues; Binwalk v2.3.3 and later allows external extraction tools to be run as an unprivileged user using the `run-as` command line option (this requires Binwalk itself to be run with root privileges). Additionally, Binwalk v2.3.3 and later will refuse to perform extraction as root unless `--run-as=root` is specified.
 
-
-### *** Python 2.7 Deprecation Notice ***
-
-Even though many major Linux distros are still shipping Python 2.7 as the default interpreter in their currently stable release, we are making the difficult decision to move binwalk support exclusively to Python 3. This is likely to make many upset and others rejoice. If you need to install binwalk into a Python 2.7 environment we will be creating a tag `python27` that will be a snapshot of `master` before all of these major changes are made. Thank you for being patient with us through this transition process.
-
-
 ### Installation and Usage
 
 * [Installation](./INSTALL.md)

--- a/src/binwalk/core/common.py
+++ b/src/binwalk/core/common.py
@@ -352,10 +352,7 @@ def BlockFile(fname, mode='r', subclass=io.FileIO, **kwargs):
                                          swap=swap,
                                          size=0)
 
-            # Python 2.6 doesn't like modes like 'rb' or 'wb'
-            mode = self.args.mode.replace('b', '')
-
-            super(self.__class__, self).__init__(fname, mode)
+            super(self.__class__, self).__init__(fname, self.args.mode)
 
             self.swap_size = self.args.swap
 
@@ -398,12 +395,6 @@ def BlockFile(fname, mode='r', subclass=io.FileIO, **kwargs):
             if self.args.peek is not None:
                 self.block_peek_size = self.args.peek
             self.base_peek_size = self.block_peek_size
-
-            # Work around for python 2.6 where FileIO._name is not defined
-            try:
-                self.name
-            except AttributeError:
-                self._name = fname
 
             self.path = os.path.abspath(self.name)
             self.seek(self.offset)

--- a/src/binwalk/core/common.py
+++ b/src/binwalk/core/common.py
@@ -3,12 +3,13 @@
 import io
 import os
 import re
+import string
 import sys
 import ast
 import platform
 import operator as op
 import binwalk.core.idb
-from binwalk.core.compat import *
+from binwalk.core.compat import str2bytes, bytes2str
 
 # Don't try to import hashlib when loaded into IDA; it doesn't work.
 if not binwalk.core.idb.LOADED_IN_IDA:

--- a/src/binwalk/core/common.py
+++ b/src/binwalk/core/common.py
@@ -200,7 +200,7 @@ def strings(filename, minimum=4):
 class GenericContainer(object):
 
     def __init__(self, **kwargs):
-        for (k, v) in iterator(kwargs):
+        for (k, v) in kwargs.items():
             setattr(self, k, v)
 
 

--- a/src/binwalk/core/compat.py
+++ b/src/binwalk/core/compat.py
@@ -1,6 +1,3 @@
-# All Python 2/3 compatibility stuffs go here.
-
-from __future__ import print_function
 import sys
 import string
 
@@ -10,75 +7,13 @@ if PY_MAJOR_VERSION > 2:
     string.letters = string.ascii_letters
 
 
-def get_class_name_from_method(method):
-    if PY_MAJOR_VERSION > 2:
-        return method.__self__.__class__.__name__
-    else:
-        return method.im_class.__name__
-
-
-def iterator(dictionary):
-    '''
-    For cross compatibility between Python 2 and Python 3 dictionaries.
-    '''
-    if PY_MAJOR_VERSION > 2:
-        return dictionary.items()
-    else:
-        return dictionary.iteritems()
-
-
-def has_key(dictionary, key):
-    '''
-    For cross compatibility between Python 2 and Python 3 dictionaries.
-    '''
-    if PY_MAJOR_VERSION > 2:
-        return key in dictionary
-    else:
-        return dictionary.has_key(key)
-
-
-def get_keys(dictionary):
-    '''
-    For cross compatibility between Python 2 and Python 3 dictionaries.
-    '''
-    if PY_MAJOR_VERSION > 2:
-        return list(dictionary.keys())
-    else:
-        return dictionary.keys()
-
-
 def str2bytes(string):
-    '''
-    For cross compatibility between Python 2 and Python 3 strings.
-    '''
-    if isinstance(string, type('')) and PY_MAJOR_VERSION > 2:
+    if isinstance(string, str):
         return bytes(string, 'latin1')
-    else:
-        return string
+    return string
 
 
 def bytes2str(bs):
-    '''
-    For cross compatibility between Python 2 and Python 3 strings.
-    '''
-    if isinstance(bs, type(b'')) and PY_MAJOR_VERSION > 2:
+    if isinstance(bs, bytes):
         return bs.decode('latin1')
-    else:
-        return bs
-
-
-def string_decode(string):
-    '''
-    For cross compatibility between Python 2 and Python 3 strings.
-    '''
-    if PY_MAJOR_VERSION > 2:
-        return bytes(string, 'utf-8').decode('unicode_escape')
-    else:
-        return string.decode('string_escape')
-
-
-def user_input(prompt=''):
-    '''
-    For getting raw user input in Python 2 and 3.
-    '''
-    return input(prompt)
+    return bs

--- a/src/binwalk/core/display.py
+++ b/src/binwalk/core/display.py
@@ -90,7 +90,7 @@ class Display(object):
         file_name = None
         self.num_columns = len(args)
 
-        if has_key(kwargs, 'file_name'):
+        if 'file_name' in kwargs:
             file_name = kwargs['file_name']
 
         if self.verbose and file_name:

--- a/src/binwalk/core/display.py
+++ b/src/binwalk/core/display.py
@@ -5,7 +5,7 @@ import sys
 import csv as pycsv
 import datetime
 import binwalk.core.common
-from binwalk.core.compat import *
+from binwalk.core.compat import bytes2str
 
 
 class Display(object):

--- a/src/binwalk/core/magic.py
+++ b/src/binwalk/core/magic.py
@@ -8,7 +8,7 @@ import re
 import struct
 import datetime
 import binwalk.core.common
-import binwalk.core.compat
+from binwalk.core.compat import str2bytes
 from binwalk.core.exceptions import ParserException
 
 
@@ -508,19 +508,19 @@ class Magic(object):
                 try:
                     # Big and little endian byte format
                     if t in ['b', 'B']:
-                        v = struct.unpack('b', binwalk.core.compat.str2bytes(self.data[o:o + 1]))[0]
+                        v = struct.unpack('b', str2bytes(self.data[o:o + 1]))[0]
                     # Little endian short format
                     elif t == 's':
-                        v = struct.unpack('<h', binwalk.core.compat.str2bytes(self.data[o:o + 2]))[0]
+                        v = struct.unpack('<h', str2bytes(self.data[o:o + 2]))[0]
                     # Little endian long format
                     elif t == 'l':
-                        v = struct.unpack('<i', binwalk.core.compat.str2bytes(self.data[o:o + 4]))[0]
+                        v = struct.unpack('<i', str2bytes(self.data[o:o + 4]))[0]
                     # Big endian short format
                     elif t == 'S':
-                        v = struct.unpack('>h', binwalk.core.compat.str2bytes(self.data[o:o + 2]))[0]
+                        v = struct.unpack('>h', str2bytes(self.data[o:o + 2]))[0]
                     # Bit endian long format
                     elif t == 'L':
-                        v = struct.unpack('>i', binwalk.core.compat.str2bytes(self.data[o:o + 4]))[0]
+                        v = struct.unpack('>i', str2bytes(self.data[o:o + 4]))[0]
                 # struct.error is thrown if there is not enough bytes in
                 # self.data for the specified format type
                 except struct.error as e:
@@ -595,7 +595,7 @@ class Magic(object):
                 # If the line has a packed format string, unpack it
                 if line.pkfmt:
                     try:
-                        dvalue = struct.unpack(line.pkfmt, binwalk.core.compat.str2bytes(self.data[start:end]))[0]
+                        dvalue = struct.unpack(line.pkfmt, str2bytes(self.data[start:end]))[0]
                     # Not enough bytes left in self.data for the specified
                     # format size
                     except struct.error as e:

--- a/src/binwalk/core/magic.py
+++ b/src/binwalk/core/magic.py
@@ -167,7 +167,7 @@ class SignatureLine(object):
                 except Exception as e:
                     raise ParserException("Failed to expand string '%s' with integer '%s' in line '%s'" % (self.value, n, line))
             try:
-                self.value = binwalk.core.compat.string_decode(self.value)
+                self.value = bytes(self.value, 'utf-8').decode('unicode_escape')
             except ValueError as e:
                 raise ParserException("Failed to decode string value '%s' in line '%s'" % (self.value, line))
         # If a regex was specified, compile it
@@ -366,7 +366,7 @@ class Signature(object):
         #
         # Thus, unless a signature has been explicitly marked as knowingly overlapping ('{overlap}'),
         # spit out a warning about any self-overlapping signatures.
-        if not binwalk.core.compat.has_key(line.tags, 'overlap'):
+        if not 'overlap' in line.tags:
             for i in range(1, line.size):
                 if restr[i:] == restr[0:(line.size - i)]:
                     binwalk.core.common.warning("Signature '%s' is a self-overlapping signature!" % line.text)
@@ -497,7 +497,7 @@ class Magic(object):
 
                 # Have we already evaluated this offset expression? If so, skip
                 # it.
-                if binwalk.core.common.has_key(replacements, text):
+                if text in replacements:
                     continue
 
                 # The offset specified in the expression is relative to the
@@ -532,7 +532,7 @@ class Magic(object):
             # Finally, replace all offset expressions with their corresponding
             # text value
             v = expression
-            for (text, value) in binwalk.core.common.iterator(replacements):
+            for (text, value) in replacements.items():
                 v = v.replace(text, "%d" % value)
 
         # If no offset, then it's just an evaluatable math expression (e.g.,
@@ -606,7 +606,7 @@ class Magic(object):
                     if line.value is None:
                         # Check to see if this is a string whose size is known and has been specified on a previous
                         # signature line.
-                        if binwalk.core.compat.has_key(tags, 'strlen') and binwalk.core.compat.has_key(line.tags, 'string'):
+                        if 'strlen' in tags and 'string' in line.tags:
                             dvalue = self.data[start:(start + tags['strlen'])]
                         # Else, just terminate the string at the first newline,
                         # carriage return, or NULL byte
@@ -704,7 +704,7 @@ class Magic(object):
                     # Process tag keywords specified in the signature line. These have already been parsed out of the
                     # original format string so that they can be processed
                     # separately from the printed description string.
-                    for (tag_name, tag_value) in binwalk.core.compat.iterator(line.tags):
+                    for (tag_name, tag_value) in line.tags.items():
                         # If the tag value is a string, try to format it
                         if isinstance(tag_value, str):
                             # Generate the tuple for the format string

--- a/src/binwalk/core/module.py
+++ b/src/binwalk/core/module.py
@@ -144,7 +144,7 @@ class Result(object):
         self.plot = True
         self.name = None
 
-        for (k, v) in iterator(kwargs):
+        for (k, v) in kwargs.items():
             setattr(self, k, v)
 
 
@@ -615,7 +615,7 @@ class Status(object):
         self.clear()
 
     def clear(self):
-        for (k, v) in iterator(self.kwargs):
+        for (k, v) in self.kwargs.items():
             setattr(self, k, v)
 
 
@@ -656,7 +656,7 @@ class Modules(object):
 
     def _set_arguments(self, argv=None, kargv=None):
         if kargv:
-            for (k, v) in iterator(kargv):
+            for (k, v) in kargv.items():
                     k = self._parse_api_opt(k)
                     if v is not True and v is not False and v is not None:
                         if not isinstance(v, list):
@@ -784,7 +784,7 @@ class Modules(object):
 
         # Add all loaded modules that marked themselves as enabled to the
         # run_modules list
-        for (module, obj) in iterator(self.executed_modules):
+        for (module, obj) in self.executed_modules.items():
             # Report the results if the module is enabled and if it is a
             # primary module or if it reported any results/errors
             if obj.enabled and (obj.PRIMARY or obj.results or obj.errors):
@@ -922,20 +922,20 @@ class Modules(object):
 
             if module_option.type == binwalk.core.common.BlockFile:
 
-                for k in get_keys(module_option.kwargs):
+                for k in list(module_option.kwargs.keys()):
                     kwargs[k] = []
                     for unk in unknown:
                         kwargs[k].append(unk)
 
-            elif has_key(args, module_option.long) and args[module_option.long] not in [None, False]:
+            elif module_option.long in args and args[module_option.long] not in [None, False]:
 
                 # Loop through all the kwargs for this command line option
-                for (name, default_value) in iterator(module_option.kwargs):
+                for (name, default_value) in module_option.kwargs.items():
 
                     # If this kwarg has not been previously processed, or if its priority is equal to or
                     # greater than the previously processed kwarg's priority,
                     # then let's process it.
-                    if not has_key(last_priority, name) or last_priority[name] <= module_option.priority:
+                    if not name in last_priority or last_priority[name] <= module_option.priority:
 
                         # Track the priority for future iterations that may
                         # process the same kwarg name
@@ -962,14 +962,14 @@ class Modules(object):
         '''
         if hasattr(obj, "KWARGS"):
             for module_argument in obj.KWARGS:
-                if has_key(kwargs, module_argument.name):
+                if module_argument.name in kwargs:
                     arg_value = kwargs[module_argument.name]
                 else:
                     arg_value = copy(module_argument.default)
 
                 setattr(obj, module_argument.name, arg_value)
 
-            for (k, v) in iterator(kwargs):
+            for (k, v) in kwargs.items():
                 if not hasattr(obj, k):
                     setattr(obj, k, v)
         else:

--- a/src/binwalk/core/module.py
+++ b/src/binwalk/core/module.py
@@ -16,7 +16,7 @@ import binwalk.core.statuserver
 import binwalk.core.common
 import binwalk.core.settings
 import binwalk.core.plugin
-from binwalk.core.compat import *
+from binwalk.core.compat import bytes2str
 from binwalk.core.exceptions import *
 
 

--- a/src/binwalk/core/plugin.py
+++ b/src/binwalk/core/plugin.py
@@ -5,7 +5,6 @@ import imp
 import inspect
 import binwalk.core.common
 import binwalk.core.settings
-from binwalk.core.compat import *
 from binwalk.core.exceptions import IgnoreFileException
 
 

--- a/src/binwalk/core/settings.py
+++ b/src/binwalk/core/settings.py
@@ -3,7 +3,6 @@
 
 import os
 import binwalk.core.common as common
-from binwalk.core.compat import *
 
 
 class Settings(object):

--- a/src/binwalk/core/statuserver.py
+++ b/src/binwalk/core/statuserver.py
@@ -5,15 +5,10 @@ import time
 import errno
 import threading
 import binwalk.core.compat
-
-# Python 2/3 compatibility
-try:
-    import SocketServer
-except ImportError:
-    import socketserver as SocketServer
+import socketserver
 
 
-class StatusRequestHandler(SocketServer.BaseRequestHandler):
+class StatusRequestHandler(socketserver.BaseRequestHandler):
 
     def handle(self):
         message_format = "%s     %3d%%     [ %d / %d ]"
@@ -61,7 +56,7 @@ class StatusRequestHandler(SocketServer.BaseRequestHandler):
         return
 
 
-class ThreadedStatusServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
+class ThreadedStatusServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
     daemon_threads = True
     allow_reuse_address = True
 
@@ -72,6 +67,5 @@ class StatusServer(object):
         self.server = ThreadedStatusServer(('127.0.0.1', port), StatusRequestHandler)
         self.server.binwalk = binwalk
 
-        t = threading.Thread(target=self.server.serve_forever)
-        t.setDaemon(True)
+        t = threading.Thread(target=self.server.serve_forever, daemon=True)
         t.start()

--- a/src/binwalk/core/statuserver.py
+++ b/src/binwalk/core/statuserver.py
@@ -4,8 +4,9 @@
 import time
 import errno
 import threading
-import binwalk.core.compat
 import socketserver
+
+from binwalk.core.compat import str2bytes
 
 
 class StatusRequestHandler(socketserver.BaseRequestHandler):
@@ -22,9 +23,9 @@ class StatusRequestHandler(socketserver.BaseRequestHandler):
             time.sleep(0.1)
 
             try:
-                self.request.send(binwalk.core.compat.str2bytes('\b' * last_status_message_len))
-                self.request.send(binwalk.core.compat.str2bytes(' ' * last_status_message_len))
-                self.request.send(binwalk.core.compat.str2bytes('\b' * last_status_message_len))
+                self.request.send(str2bytes('\b' * last_status_message_len))
+                self.request.send(str2bytes(' ' * last_status_message_len))
+                self.request.send(str2bytes('\b' * last_status_message_len))
 
                 if self.server.binwalk.status.shutdown:
                     self.server.binwalk.status.finished = True
@@ -42,7 +43,7 @@ class StatusRequestHandler(socketserver.BaseRequestHandler):
                     continue
 
                 last_status_message_len = len(status_message)
-                self.request.send(binwalk.core.compat.str2bytes(status_message))
+                self.request.send(str2bytes(status_message))
                 message_sent = True
             except IOError as e:
                 if e.errno == errno.EPIPE:

--- a/src/binwalk/modules/compression.py
+++ b/src/binwalk/modules/compression.py
@@ -4,8 +4,8 @@
 import os
 import zlib
 import struct
-import binwalk.core.compat
 import binwalk.core.common
+from binwalk.core.compat import str2bytes, bytes2str
 from binwalk.core.module import Option, Kwarg, Module
 try:
     import lzma
@@ -81,7 +81,7 @@ class LZMA(object):
 
     def parse_header(self, header):
         (pb, lp, lc) = self.parse_property(header[0])
-        dictionary = struct.unpack("<I", binwalk.core.compat.str2bytes(header[1:5]))[0]
+        dictionary = struct.unpack("<I", str2bytes(header[1:5]))[0]
         return LZMAHeader(pb=pb, lp=lp, lc=lc, dictionary=dictionary)
 
     def build_properties(self):
@@ -104,10 +104,10 @@ class LZMA(object):
 
         if self.module.partial_scan == True:
             # For partial scans, only use the largest dictionary value
-            self.dictionaries.append(binwalk.core.compat.bytes2str(struct.pack("<I", 2 ** 25)))
+            self.dictionaries.append(bytes2str(struct.pack("<I", 2 ** 25)))
         else:
             for n in range(16, 26):
-                self.dictionaries.append(binwalk.core.compat.bytes2str(struct.pack("<I", 2 ** n)))
+                self.dictionaries.append(bytes2str(struct.pack("<I", 2 ** n)))
 
     def build_headers(self):
         self.headers = set()
@@ -124,7 +124,7 @@ class LZMA(object):
             # The only acceptable exceptions are those indicating that the
             # input data was truncated.
             try:
-                final_data = binwalk.core.compat.str2bytes(header + data)
+                final_data = str2bytes(header + data)
                 lzma.decompress(final_data)
                 result = self.parse_header(header)
                 break
@@ -184,7 +184,7 @@ class Deflate(object):
                     in_data += data[:dlen]
 
                 try:
-                    out_data = zlib.decompress(binwalk.core.compat.str2bytes(in_data), -15)
+                    out_data = zlib.decompress(str2bytes(in_data), -15)
                     with binwalk.core.common.BlockFile(out_file, 'w') as fp_out:
                         fp_out.write(out_data)
                     retval = True
@@ -200,7 +200,7 @@ class Deflate(object):
         try:
             # Negative window size (e.g., -15) indicates that raw decompression
             # should be performed
-            zlib.decompress(binwalk.core.compat.str2bytes(data), -15)
+            zlib.decompress(str2bytes(data), -15)
         except zlib.error as e:
             if not str(e).startswith("Error -5"):
                 # Bad data.

--- a/src/binwalk/modules/compression.py
+++ b/src/binwalk/modules/compression.py
@@ -16,7 +16,7 @@ except ImportError:
 class LZMAHeader(object):
 
     def __init__(self, **kwargs):
-        for (k, v) in binwalk.core.compat.iterator(kwargs):
+        for (k, v) in kwargs.items():
             setattr(self, k, v)
 
 

--- a/src/binwalk/modules/disasm.py
+++ b/src/binwalk/modules/disasm.py
@@ -7,14 +7,14 @@ from binwalk.core.module import Module, Option, Kwarg
 class ArchResult(object):
 
     def __init__(self, **kwargs):
-        for (k, v) in binwalk.core.compat.iterator(kwargs):
+        for (k, v) in kwargs.items():
             setattr(self, k, v)
 
 
 class Architecture(object):
 
     def __init__(self, **kwargs):
-        for (k, v) in binwalk.core.compat.iterator(kwargs):
+        for (k, v) in kwargs.items():
             setattr(self, k, v)
 
 

--- a/src/binwalk/modules/disasm.py
+++ b/src/binwalk/modules/disasm.py
@@ -1,6 +1,6 @@
 import capstone
 import binwalk.core.common
-import binwalk.core.compat
+from binwalk.core.compat import str2bytes
 from binwalk.core.module import Module, Option, Kwarg
 
 
@@ -123,7 +123,7 @@ class Disasm(Module):
                     # Don't pass the entire data block into disasm_lite, it's horribly inefficient
                     # to pass large strings around in Python. Break it up into
                     # smaller code blocks instead.
-                    code_block = binwalk.core.compat.str2bytes(data[block_offset:block_offset + self.disasm_data_size])
+                    code_block = str2bytes(data[block_offset:block_offset + self.disasm_data_size])
 
                     # If this code block doesn't contain at least two different bytes, skip it
                     # to prevent false positives (e.g., "\x00\x00\x00\x00" is a

--- a/src/binwalk/modules/entropy.py
+++ b/src/binwalk/modules/entropy.py
@@ -5,7 +5,7 @@ import sys
 import math
 import zlib
 import binwalk.core.common
-from binwalk.core.compat import *
+from binwalk.core.compat import str2bytes
 from binwalk.core.module import Module, Option, Kwarg
 
 #try:

--- a/src/binwalk/modules/entropy.py
+++ b/src/binwalk/modules/entropy.py
@@ -105,12 +105,12 @@ class Entropy(Module):
                 self.algorithm = self.shannon
 
         # Get a list of all other module's results to mark on the entropy graph
-        for (module, obj) in iterator(self.modules):
+        for (module, obj) in self.modules.items():
             for result in obj.results:
                 if result.plot and result.file and result.description:
                     description = result.description.split(',')[0]
 
-                    if not has_key(self.file_markers, result.file.name):
+                    if not result.file.name in self.file_markers:
                         self.file_markers[result.file.name] = []
 
                     if len(description) > self.max_description_length:
@@ -314,7 +314,7 @@ class Entropy(Module):
         ax.plot(-(max(x)*.001), 1.1, lw=0)
         ax.plot(-(max(x)*.001), 0, lw=0)
 
-        if self.show_legend and has_key(self.file_markers, fname):
+        if self.show_legend and fname in self.file_markers:
             for (offset, description) in self.file_markers[fname]:
                 # If this description has already been plotted at a different offset, we need to
                 # use the same color for the marker, but set the description to None to prevent
@@ -322,7 +322,7 @@ class Entropy(Module):
                 #
                 # Else, get the next color and use it to mark descriptions of
                 # this type.
-                if has_key(plotted_colors, description):
+                if description in plotted_colors:
                     color = plotted_colors[description]
                     description = None
                 else:

--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -10,7 +10,6 @@ import shlex
 import tempfile
 import subprocess
 import binwalk.core.common
-from binwalk.core.compat import *
 from binwalk.core.exceptions import ModuleException
 from binwalk.core.module import Module, Option, Kwarg
 from binwalk.core.common import file_size, file_md5, unique_file_name, BlockFile

--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -18,7 +18,7 @@ from binwalk.core.common import file_size, file_md5, unique_file_name, BlockFile
 
 class ExtractDetails(object):
     def __init__(self, **kwargs):
-        for (k, v) in iterator(kwargs):
+        for (k, v) in kwargs.items():
             setattr(self, k, v)
 
 
@@ -246,7 +246,7 @@ class Extractor(Module):
         if r.valid and r.extract and r.display and (not self.max_count or self.extraction_count < self.max_count):
             # Create some extract output for this file, it it doesn't already
             # exist
-            if not binwalk.core.common.has_key(self.output, r.file.path):
+            if r.file.path not in self.output:
                 self.output[r.file.path] = ExtractInfo()
 
             # Attempt extraction
@@ -277,7 +277,7 @@ class Extractor(Module):
                 # If this is a newly created output directory, self.last_directory_listing won't have a record of it.
                 # If we've extracted other files to this directory before, it
                 # will.
-                if not has_key(self.last_directory_listing, extraction_directory):
+                if extraction_directory not in self.last_directory_listing:
                     self.last_directory_listing[extraction_directory] = set()
 
                 # Loop through a list of newly created files (i.e., files that
@@ -439,7 +439,7 @@ class Extractor(Module):
 
         for i in range(0, len(self.extract_rules)):
             if self.extract_rules[i]['regex'].search(description):
-                if has_key(self.extract_rules[i], key):
+                if key in self.extract_rules[i]:
                     self.extract_rules[i][key] = value
                     count += 1
 
@@ -540,7 +540,7 @@ class Extractor(Module):
         '''
         # If we have not already created an output directory for this target
         # file, create one now
-        if not has_key(self.extraction_directories, path):
+        if path not in self.extraction_directories:
             basedir = os.path.dirname(path)
             basename = os.path.basename(path)
 
@@ -902,7 +902,7 @@ class Extractor(Module):
 
         try:
             if callable(cmd):
-                command_list.append(get_class_name_from_method(cmd))
+                command_list.append(cmd.__self__.__class__.__name__)
 
                 try:
                     retval = cmd(fname)

--- a/src/binwalk/modules/general.py
+++ b/src/binwalk/modules/general.py
@@ -10,7 +10,6 @@ import binwalk.core.idb
 import binwalk.core.common
 import binwalk.core.display
 import binwalk.core.settings
-from binwalk.core.compat import *
 from binwalk.core.module import Module, Option, Kwarg, show_help
 
 

--- a/src/binwalk/modules/hexdiff.py
+++ b/src/binwalk/modules/hexdiff.py
@@ -1,7 +1,6 @@
 import sys
 import string
 import binwalk.core.common as common
-from binwalk.core.compat import *
 from binwalk.core.module import Module, Option, Kwarg
 
 

--- a/src/binwalk/modules/hexdiff.py
+++ b/src/binwalk/modules/hexdiff.py
@@ -90,10 +90,10 @@ class HexDiff(Module):
     def hexascii(self, target_data, byte, offset):
         color = "green"
 
-        for (fp_i, data_i) in iterator(target_data):
+        for (fp_i, data_i) in target_data.items():
             diff_count = 0
 
-            for (fp_j, data_j) in iterator(target_data):
+            for (fp_j, data_j) in target_data.items():
                 if fp_i == fp_j:
                     continue
 

--- a/src/binwalk/plugins/gzipvalid.py
+++ b/src/binwalk/plugins/gzipvalid.py
@@ -1,7 +1,7 @@
 import zlib
-import binwalk.core.compat
 import binwalk.core.plugin
 from binwalk.core.common import BlockFile
+from binwalk.core.compat import str2bytes
 
 
 class GzipValidPlugin(binwalk.core.plugin.Plugin):
@@ -38,7 +38,7 @@ class GzipValidPlugin(binwalk.core.plugin.Plugin):
 
             # Check if this is valid deflate data (no zlib header)
             try:
-                zlib.decompress(binwalk.core.compat.str2bytes(data))
+                zlib.decompress(str2bytes(data))
             except zlib.error as e:
                 error = str(e)
                 # Truncated input data results in error -5.

--- a/src/binwalk/plugins/jffs2valid.py
+++ b/src/binwalk/plugins/jffs2valid.py
@@ -1,6 +1,7 @@
 import struct
 import binascii
 import binwalk.core.plugin
+from binwalk.core.compat import str2bytes
 
 
 class JFFS2ValidPlugin(binwalk.core.plugin.Plugin):
@@ -16,7 +17,7 @@ class JFFS2ValidPlugin(binwalk.core.plugin.Plugin):
 
     def _check_crc(self, node_header):
         # struct and binascii want a bytes object in Python3
-        node_header = binwalk.core.compat.str2bytes(node_header)
+        node_header = str2bytes(node_header)
 
         # Get the header's reported CRC value
         if node_header[0:2] == b"\x19\x85":

--- a/src/binwalk/plugins/lzmaextract.py
+++ b/src/binwalk/plugins/lzmaextract.py
@@ -11,14 +11,7 @@ class LZMAExtractPlugin(binwalk.core.plugin.Plugin):
 
     def init(self):
         try:
-            # lzma package in Python 2.0 decompress() does not handle multiple
-            # compressed streams, only first stream is extracted.
-            # backports.lzma package could be used to keep consistent
-            # behaviour.
-            try:
-                import lzma
-            except ImportError:
-                from backports import lzma
+            import lzma
 
             self.decompressor = lzma.decompress
 

--- a/src/binwalk/plugins/lzmavalid.py
+++ b/src/binwalk/plugins/lzmavalid.py
@@ -1,6 +1,6 @@
 import binwalk.core.plugin
-import binwalk.core.compat
 from binwalk.core.common import BlockFile
+from binwalk.core.compat import str2bytes
 
 
 class LZMAPlugin(binwalk.core.plugin.Plugin):
@@ -34,7 +34,7 @@ class LZMAPlugin(binwalk.core.plugin.Plugin):
             # The only acceptable exceptions are those indicating that the
             # input data was truncated.
             try:
-                self.decompressor(binwalk.core.compat.str2bytes(data))
+                self.decompressor(str2bytes(data))
             except IOError as e:
                 # The Python2 module gives this error on truncated input data.
                 if str(e) != "unknown BUF error":

--- a/src/binwalk/plugins/ubivalid.py
+++ b/src/binwalk/plugins/ubivalid.py
@@ -1,7 +1,7 @@
 import struct
 import binascii
 import binwalk.core.plugin
-import binwalk.core.compat
+from binwalk.core.compat import str2bytes
 
 
 class UBIValidPlugin(binwalk.core.plugin.Plugin):
@@ -58,7 +58,7 @@ class UBIValidPlugin(binwalk.core.plugin.Plugin):
             # Seek to and read the suspected UBI erase count header
             fd = self.module.config.open_file(result.file.path, offset=result.offset)
 
-            ec_header = binwalk.core.compat.str2bytes(fd.read(1024))
+            ec_header = str2bytes(fd.read(1024))
             fd.close()
 
             result.valid = self._check_crc(ec_header[0:64])

--- a/src/binwalk/plugins/unpfs.py
+++ b/src/binwalk/plugins/unpfs.py
@@ -2,19 +2,20 @@ import os
 import errno
 import struct
 import binwalk.core.common
-import binwalk.core.compat
 import binwalk.core.plugin
+from binwalk.core.compat import str2bytes
+
 
 class PFSCommon(object):
 
     def _make_short(self, data, endianness):
         """Returns a 2 byte integer."""
-        data = binwalk.core.compat.str2bytes(data)
+        data = str2bytes(data)
         return struct.unpack('%sH' % endianness, data)[0]
 
     def _make_int(self, data, endianness):
         """Returns a 4 byte integer."""
-        data = binwalk.core.compat.str2bytes(data)
+        data = str2bytes(data)
         return struct.unpack('%sI' % endianness, data)[0]
 
 class PFS(PFSCommon):

--- a/src/binwalk/plugins/zlibextract.py
+++ b/src/binwalk/plugins/zlibextract.py
@@ -1,8 +1,8 @@
 import os
 import zlib
-import binwalk.core.compat
 import binwalk.core.common
 import binwalk.core.plugin
+from binwalk.core.compat import str2bytes
 
 
 class ZLIBExtractPlugin(binwalk.core.plugin.Plugin):
@@ -28,7 +28,7 @@ class ZLIBExtractPlugin(binwalk.core.plugin.Plugin):
             fpin = binwalk.core.common.BlockFile(fname)
             fpout = binwalk.core.common.BlockFile(outfile, 'w')
 
-            plaintext = zlib.decompress(binwalk.core.compat.str2bytes(fpin.read()))
+            plaintext = zlib.decompress(str2bytes(fpin.read()))
             fpout.write(plaintext)
 
             fpin.close()

--- a/src/binwalk/plugins/zlibvalid.py
+++ b/src/binwalk/plugins/zlibvalid.py
@@ -1,7 +1,7 @@
 import zlib
-import binwalk.core.compat
 import binwalk.core.plugin
 from binwalk.core.common import BlockFile
+from binwalk.core.compat import str2bytes
 
 
 class ZlibValidPlugin(binwalk.core.plugin.Plugin):
@@ -37,7 +37,7 @@ class ZlibValidPlugin(binwalk.core.plugin.Plugin):
             #   1. It decompresses without error
             #   2. Decompression fails only because of truncated input
             try:
-                zlib.decompress(binwalk.core.compat.str2bytes(data))
+                zlib.decompress(str2bytes(data))
             except zlib.error as e:
                 # Error -5, incomplete or truncated data input
                 if not str(e).startswith("Error -5"):


### PR DESCRIPTION
This repo has required Python 3 since approximately https://github.com/ReFirmLabs/binwalk/commit/2f6c7b3ae07cb4134da0429bd45f37ee2245efa0 (2020) but a whole bunch of stuff remained.