### PR TITLE
Updated deps.sh to reflect branch rename in ubi_reader from 'master' …

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -115,7 +115,7 @@ function install_cramfstools
 
 function install_ubireader
 {
-    git clone --quiet --depth 1 --branch "master" https://github.com/jrspruitt/ubi_reader
+    git clone --quiet --depth 1 --branch "main" https://github.com/jrspruitt/ubi_reader
     (cd ubi_reader && $SUDO $PYTHON setup.py install)
     $SUDO rm -rf ubi_reader
 }


### PR DESCRIPTION
The maintainers over at [UBI Reader](https://github.com/onekey-sec/ubi_reader) changed their default branch name to "main" yesterday. The `clone` commands in `deps.sh` assumes there's a "master" branch which broke `deps.sh`, so I changed it to clone the "main" branch instead of "master"