### PR TITLE
Workaround for missing `pwd` module on Windows

### DIFF
--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -4,7 +4,16 @@
 
 import os
 import re
-import pwd
+
+# Windows workaround for missing module 'pwd'
+if os.name == 'nt':
+    class Pwd():
+        def pwgetnam(self, user):
+            pass
+    pwd = Pwd()
+else:
+    import pwd
+
 import stat
 import shlex
 import tempfile


### PR DESCRIPTION
Windows platforms do not ship the `pwd` module.

This solves:

```
ModuleNotFoundError: No module named 'pwd'
```

Code snippet was sourced from here: [(stackoverflow.com)](https://stackoverflow.com/a/16529233/21885072)