### PR TITLE
Fix ubi_reader dependency

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -115,7 +115,7 @@ function install_cramfstools
 
 function install_ubireader
 {
-    git clone --quiet --depth 1 --branch "master" https://github.com/jrspruitt/ubi_reader
+    git clone --quiet --depth 1 -b v0.8.5-master https://github.com/jrspruitt/ubi_reader
     (cd ubi_reader && $SUDO $PYTHON setup.py install)
     $SUDO rm -rf ubi_reader
 }


### PR DESCRIPTION
In ubi_reader's repository there is no "master" branch anymore. Furthermore, the "main" branch does not use python setup.py anymore. Fixed by cloning the latest version having the setup.py install