### PR TITLE
[lib]: fix the importlib usage for python 3.12

### DIFF
--- a/src/binwalk/core/module.py
+++ b/src/binwalk/core/module.py
@@ -704,14 +704,25 @@ class Modules(object):
                 modules[module] = module.PRIORITY
 
         # user-defined modules
-        import imp
+        import importlib.util
+        import importlib.machinery
+        def load_source(modname, filename):
+            loader = importlib.machinery.SourceFileLoader(modname, filename)
+            spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+            module = importlib.util.module_from_spec(spec)
+			# The module is always executed and not cached in sys.modules.
+			# Uncomment the following line to cache the module.
+			# sys.modules[module.__name__] = module
+            loader.exec_module(module)
+            return module
+
         user_modules = binwalk.core.settings.Settings().user.modules
         for file_name in os.listdir(user_modules):
             if not file_name.endswith('.py'):
                 continue
             module_name = file_name[:-3]
             try:
-                user_module = imp.load_source(module_name, os.path.join(user_modules, file_name))
+                user_module = load_source(module_name, os.path.join(user_modules, file_name))
             except KeyboardInterrupt as e:
                 raise e
             except Exception as e:


### PR DESCRIPTION
1. imp is deprecated and replaced by importlib
2. reimplement the load_source according to https://docs.python.org/3/whatsnew/3.12.html?highlight=load_source#imp