### PR TITLE
add basic LUKS header support

### DIFF
--- a/src/magic.rs
+++ b/src/magic.rs
@@ -933,5 +933,17 @@ pub fn patterns() -> Vec<signatures::common::Signature> {
         extractor: None,
     });
 
+    // LUKS
+    binary_signatures.push(signatures::common::Signature {
+        name: "luks".to_string(),
+        short: false,
+        magic_offset: 0,
+        always_display: false,
+        magic: signatures::luks::luks_magic(),
+        parser: signatures::luks::luks_parser,
+        description: signatures::luks::DESCRIPTION.to_string(),
+        extractor: None,
+    });
+
     return binary_signatures;
 }

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -135,6 +135,7 @@ pub mod jboot;
 pub mod jffs2;
 pub mod jpeg;
 pub mod linux;
+pub mod luks;
 pub mod lz4;
 pub mod lzfse;
 pub mod lzma;

--- a/src/signatures/luks.rs
+++ b/src/signatures/luks.rs
@@ -1,0 +1,30 @@
+use crate::signatures::common::{SignatureError, SignatureResult, CONFIDENCE_MEDIUM};
+use crate::structures::luks::parse_luks_header;
+
+/// Human readable description
+pub const DESCRIPTION: &str = "LUKS Header";
+
+/// LUKS Headers start with these bytes
+pub fn luks_magic() -> Vec<Vec<u8>> {
+    return vec![b"LUKS\xBA\xBE".to_vec()];
+}
+
+/// Parse and validate the LUKS header
+pub fn luks_parser(file_data: &Vec<u8>, offset: usize) -> Result<SignatureResult, SignatureError> {
+    // Successful result
+    let mut result = SignatureResult {
+        offset: offset,
+        name: "luks".to_string(),
+        description: DESCRIPTION.to_string(),
+        confidence: CONFIDENCE_MEDIUM,
+        ..Default::default()
+    };
+
+    // If the header is parsed successfully, consider it valid
+    if let Ok(luks_header) = parse_luks_header(&file_data[offset..]) {
+        result.description = format!("LUKS header, version: {}, hash fn: {}", luks_header.version, luks_header.hashfn);
+        return Ok(result);
+    }
+
+    return Err(SignatureError);
+}

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -116,6 +116,7 @@ pub mod iso9660;
 pub mod jboot;
 pub mod jffs2;
 pub mod linux;
+pub mod luks;
 pub mod lz4;
 pub mod lzfse;
 pub mod lzma;

--- a/src/structures/luks.rs
+++ b/src/structures/luks.rs
@@ -1,0 +1,37 @@
+use crate::structures::common::{self, StructureError};
+
+/// Struct to store some useful LUKS info
+#[derive(Debug, Default, Clone)]
+pub struct LUKSHeader {
+    pub version: usize,
+    pub hashfn: String,
+}
+
+/// Partially parses an ELF header
+pub fn parse_luks_header(luks_data: &[u8]) -> Result<LUKSHeader, StructureError> {
+
+    const HASHFN_START: usize = 72;
+    const HASHFN_END: usize = 104;
+
+    let luks_base_structure = vec![
+        ("magic_1", "u32"),
+        ("magic_2", "u16"),
+        ("version", "u16"),
+    ];
+
+    let mut luks_hdr_info = LUKSHeader {
+        ..Default::default()
+    };
+
+    if let Ok(luks_base) = common::parse(&luks_data, &luks_base_structure, "big") {
+        if luks_base["version"] == 1 || luks_base["version"] == 2 {
+            luks_hdr_info.version = luks_base["version"];
+            if let Ok(hashfn) = String::from_utf8(luks_data[HASHFN_START..HASHFN_END].to_vec()) {
+                luks_hdr_info.hashfn = hashfn;
+                return Ok(luks_hdr_info);
+            }
+        }
+    }
+
+    return Err(StructureError);
+}


### PR DESCRIPTION
This PR adds basic support for detecting LUKS headers:
https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup

Currently I'm only parsing the version and the hash function because those are the two fields that are in the same offsets in versions 1 and 2 of LUKS.

After that version 1 and 2 start to diverge, and will take some more work to parse them separately.

Test data was generated as follows:
```
dd if=/dev/zero of=test1.bin count=100000 bs=1024
dd if=/dev/zero of=test2.bin count=100000 bs=1024
cryptsetup luksFormat --type luks1 test1.bin
cryptsetup luksFormat --type luks2 test2.bin
echo -e "LUKS\xba\xbe\x00\xff" > test3.bin # FALSE POSITIVE TEST (invalid version number)
```

Output for LUKS vesion 1:
```
                 /home/nmatt/work/research/binwalkv3/testfw/test1.bin
--------------------------------------------------------------------------------------
DECIMAL                            HEXADECIMAL                        DESCRIPTION
--------------------------------------------------------------------------------------
0                                  0x0                                LUKS header, 
                                                                      version: 1, 
                                                                      hash fn: 
                                                                      sha256
--------------------------------------------------------------------------------------

Analyzed 1 file for 78 file signatures (180 magic patterns) in 40.0 milliseconds
```

Output for LUKS vesion 2:
```
                 /home/nmatt/work/research/binwalkv3/testfw/test2.bin
--------------------------------------------------------------------------------------
DECIMAL                            HEXADECIMAL                        DESCRIPTION
--------------------------------------------------------------------------------------
0                                  0x0                                LUKS header, 
                                                                      version: 2, 
                                                                      hash fn: 
                                                                      sha256
--------------------------------------------------------------------------------------

Analyzed 1 file for 78 file signatures (180 magic patterns) in 349.0 milliseconds
```

test3.bin did not get flagged as a LUKS header. (correctly)

Thanks,
Matt