### PR TITLE
switch from p7zip to 7zip

### DIFF
--- a/src/extractors/sevenzip.rs
+++ b/src/extractors/sevenzip.rs
@@ -24,7 +24,7 @@ use crate::extractors;
 /// ```
 pub fn sevenzip_extractor() -> extractors::common::Extractor {
     extractors::common::Extractor {
-        utility: extractors::common::ExtractorType::External("7z".to_string()),
+        utility: extractors::common::ExtractorType::External("7zz".to_string()),
         extension: "bin".to_string(),
         arguments: vec![
             "x".to_string(),   // Perform extraction


### PR DESCRIPTION
The latest 7zip version supports unix systems, so it can be used instead of the old unix port (last version of p7zip is from 2016, see https://sourceforge.net/projects/p7zip/). 

Related with this I have a small question. How to have multiple extractors for the same signature? I have seen in display.rs that it supports multiple extractors, but I didn't see an argument for the signature types in the Extractor type.