### PR TITLE
Explicitly pass endianness to sasquatch

### DIFF
--- a/src/extractors/squashfs.rs
+++ b/src/extractors/squashfs.rs
@@ -33,13 +33,35 @@ pub fn squashfs_extractor() -> extractors::common::Extractor {
     }
 }
 
+/// Describes how to run the sasquatch utility to extract little endian SquashFS images
+///
+/// ```
+/// use std::io::ErrorKind;
+/// use std::process::Command;
+/// use binwalk::extractors::common::ExtractorType;
+/// use binwalk::extractors::squashfs::squashfs_le_extractor;
+///
+/// match squashfs_le_extractor().utility {
+///     ExtractorType::None => panic!("Invalid extractor type of None"),
+///     ExtractorType::Internal(func) => println!("Internal extractor OK: {:?}", func),
+///     ExtractorType::External(cmd) => {
+///         if let Err(e) = Command::new(&cmd).output() {
+///             if e.kind() == ErrorKind::NotFound {
+///                 panic!("External extractor '{}' not found", cmd);
+///             } else {
+///                 panic!("Failed to execute external extractor '{}': {}", cmd, e);
+///             }
+///         }
+///     }
+/// }
+/// ```
 pub fn squashfs_le_extractor() -> extractors::common::Extractor {
     extractors::common::Extractor {
         utility: extractors::common::ExtractorType::External("sasquatch".to_string()),
         extension: "sqsh".to_string(),
         arguments: vec![
             "-le".to_string(),
-            extractors::common::SOURCE_FILE_PLACEHOLDER.to_string()
+            extractors::common::SOURCE_FILE_PLACEHOLDER.to_string(),
         ],
         // Exit code may be 0 or 2; 2 indicates running as not root, but otherwise extraction is ok
         exit_codes: vec![0, 2],
@@ -47,13 +69,35 @@ pub fn squashfs_le_extractor() -> extractors::common::Extractor {
     }
 }
 
+/// Describes how to run the sasquatch utility to extract big endian SquashFS images
+///
+/// ```
+/// use std::io::ErrorKind;
+/// use std::process::Command;
+/// use binwalk::extractors::common::ExtractorType;
+/// use binwalk::extractors::squashfs::squashfs_be_extractor;
+///
+/// match squashfs_be_extractor().utility {
+///     ExtractorType::None => panic!("Invalid extractor type of None"),
+///     ExtractorType::Internal(func) => println!("Internal extractor OK: {:?}", func),
+///     ExtractorType::External(cmd) => {
+///         if let Err(e) = Command::new(&cmd).output() {
+///             if e.kind() == ErrorKind::NotFound {
+///                 panic!("External extractor '{}' not found", cmd);
+///             } else {
+///                 panic!("Failed to execute external extractor '{}': {}", cmd, e);
+///             }
+///         }
+///     }
+/// }
+/// ```
 pub fn squashfs_be_extractor() -> extractors::common::Extractor {
     extractors::common::Extractor {
         utility: extractors::common::ExtractorType::External("sasquatch".to_string()),
         extension: "sqsh".to_string(),
         arguments: vec![
             "-be".to_string(),
-            extractors::common::SOURCE_FILE_PLACEHOLDER.to_string()
+            extractors::common::SOURCE_FILE_PLACEHOLDER.to_string(),
         ],
         // Exit code may be 0 or 2; 2 indicates running as not root, but otherwise extraction is ok
         exit_codes: vec![0, 2],

--- a/src/extractors/squashfs.rs
+++ b/src/extractors/squashfs.rs
@@ -33,6 +33,34 @@ pub fn squashfs_extractor() -> extractors::common::Extractor {
     }
 }
 
+pub fn squashfs_le_extractor() -> extractors::common::Extractor {
+    extractors::common::Extractor {
+        utility: extractors::common::ExtractorType::External("sasquatch".to_string()),
+        extension: "sqsh".to_string(),
+        arguments: vec![
+            "-le".to_string(),
+            extractors::common::SOURCE_FILE_PLACEHOLDER.to_string()
+        ],
+        // Exit code may be 0 or 2; 2 indicates running as not root, but otherwise extraction is ok
+        exit_codes: vec![0, 2],
+        ..Default::default()
+    }
+}
+
+pub fn squashfs_be_extractor() -> extractors::common::Extractor {
+    extractors::common::Extractor {
+        utility: extractors::common::ExtractorType::External("sasquatch".to_string()),
+        extension: "sqsh".to_string(),
+        arguments: vec![
+            "-be".to_string(),
+            extractors::common::SOURCE_FILE_PLACEHOLDER.to_string()
+        ],
+        // Exit code may be 0 or 2; 2 indicates running as not root, but otherwise extraction is ok
+        exit_codes: vec![0, 2],
+        ..Default::default()
+    }
+}
+
 /// Describes how to run the sasquatch-v4be utility to extract big endian SquashFSv4 images
 ///
 /// ```

--- a/src/signatures/squashfs.rs
+++ b/src/signatures/squashfs.rs
@@ -1,5 +1,5 @@
 use crate::common::epoch_to_string;
-use crate::extractors::squashfs::squashfs_v4_be_extractor;
+use crate::extractors::squashfs::{squashfs_be_extractor, squashfs_le_extractor, squashfs_v4_be_extractor};
 use crate::signatures::common::{SignatureError, SignatureResult, CONFIDENCE_HIGH};
 use crate::structures::squashfs::{parse_squashfs_header, parse_squashfs_uid_entry};
 use std::collections::HashMap;
@@ -90,11 +90,13 @@ pub fn squashfs_parser(file_data: &[u8], offset: usize) -> Result<SignatureResul
                                     [&squashfs_header.compression]
                                     .to_string();
 
-                                // Standard SquashFSv4 is little endian only; devices that implement a custom big endian version must use a custom extractor
-                                if squashfs_header.major_version == SQUASHFSV4
-                                    && squashfs_header.endianness == "big"
-                                {
+                                // Select the appropriate extractor to use
+                                if squashfs_header.endianness == "little" {
+                                    result.preferred_extractor = Some(squashfs_le_extractor());
+                                } else if squashfs_header.major_version == SQUASHFSV4 {
                                     result.preferred_extractor = Some(squashfs_v4_be_extractor());
+                                } else {
+                                    result.preferred_extractor = Some(squashfs_be_extractor());
                                 }
 
                                 result.size = squashfs_header.image_size;

--- a/src/signatures/squashfs.rs
+++ b/src/signatures/squashfs.rs
@@ -1,5 +1,7 @@
 use crate::common::epoch_to_string;
-use crate::extractors::squashfs::{squashfs_be_extractor, squashfs_le_extractor, squashfs_v4_be_extractor};
+use crate::extractors::squashfs::{
+    squashfs_be_extractor, squashfs_le_extractor, squashfs_v4_be_extractor,
+};
 use crate::signatures::common::{SignatureError, SignatureResult, CONFIDENCE_HIGH};
 use crate::structures::squashfs::{parse_squashfs_header, parse_squashfs_uid_entry};
 use std::collections::HashMap;


### PR DESCRIPTION
The `sasquatch` utility sometimes does not correctly detect the endianness of a SquashFS image.

Explicitly specify the endianness when executing `sasquatch`.