### PR TITLE
Carve file data to disk

### DIFF
--- a/src/cliparser.rs
+++ b/src/cliparser.rs
@@ -19,6 +19,10 @@ pub struct CliArgs {
     #[arg(short, long)]
     pub extract: bool,
 
+    /// Carve raw file data to disk during extraction
+    #[arg(short, long)]
+    pub carve: bool,
+
     /// Recursively scan extracted files
     #[arg(short = 'M', long)]
     pub matryoshka: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,6 +162,7 @@ fn main() {
                 binwalker.clone(),
                 target_file,
                 cliargs.extract,
+                cliargs.carve,
                 worker_tx.clone(),
             );
         }
@@ -267,11 +268,18 @@ fn spawn_worker(
     bw: binwalk::Binwalk,
     target_file: String,
     do_extraction: bool,
+    do_carve: bool,
     worker_tx: mpsc::Sender<AnalysisResults>,
 ) {
     pool.execute(move || {
         // Analyze target file, with extraction, if specified
         let results = bw.analyze(&target_file, do_extraction);
+
+        // If data carving was requested as part of extraction, carve analysis results to disk
+        if do_extraction && do_carve && !bw.carve(&results) {
+            error!("Failed to carve raw data to disk");
+        }
+
         // Report file results back to main thread
         if let Err(e) = worker_tx.send(results) {
             panic!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,8 +276,8 @@ fn spawn_worker(
         let results = bw.analyze(&target_file, do_extraction);
 
         // If data carving was requested as part of extraction, carve analysis results to disk
-        if do_extraction && do_carve && !bw.carve(&results) {
-            error!("Failed to carve raw data to disk");
+        if do_extraction && do_carve {
+            let _ = bw.carve(&results);
         }
 
         // Report file results back to main thread


### PR DESCRIPTION
Adds `--carve` command line option which carves known and unknown data blocks from a file to disk during extraction.