### PR TITLE
refactor: replace &String with &str to enhance generality

### DIFF
--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -96,7 +96,7 @@
 //! }
 //!
 //! /// This function extracts the contents of a FooBar file
-//! pub fn extract_foobar_file(file_data: Vec<u8>, offset: usize, output_directory: Option<&String>) -> ExtractionResult {
+//! pub fn extract_foobar_file(file_data: Vec<u8>, offset: usize, output_directory: Option<&str>) -> ExtractionResult {
 //!
 //!     // This will be the return value
 //!     let mut result = ExtractionResult{..Default::default()};

--- a/src/extractors/androidsparse.rs
+++ b/src/extractors/androidsparse.rs
@@ -35,7 +35,7 @@ pub fn android_sparse_extractor() -> Extractor {
 pub fn extract_android_sparse(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const OUTFILE_NAME: &str = "unsparsed.img";
 
@@ -102,7 +102,7 @@ fn extract_chunk(
     sparse_header: &androidsparse::AndroidSparseHeader,
     chunk_header: &androidsparse::AndroidSparseChunkHeader,
     chunk_data: &[u8],
-    outfile: &String,
+    outfile: &str,
     chroot: &Chroot,
 ) -> bool {
     if chunk_header.is_raw {

--- a/src/extractors/arcadyan.rs
+++ b/src/extractors/arcadyan.rs
@@ -34,7 +34,7 @@ pub fn obfuscated_lzma_extractor() -> Extractor {
 pub fn extract_obfuscated_lzma(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const LZMA_DATA_OFFSET: usize = 4;
     const MIN_DATA_SIZE: usize = 0x100;

--- a/src/extractors/autel.rs
+++ b/src/extractors/autel.rs
@@ -37,7 +37,7 @@ pub fn autel_extractor() -> Extractor {
 pub fn autel_deobfuscate(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const OUTPUT_FILE_NAME: &str = "autel.decoded";
 

--- a/src/extractors/bzip2.rs
+++ b/src/extractors/bzip2.rs
@@ -34,7 +34,7 @@ pub fn bzip2_extractor() -> Extractor {
 pub fn bzip2_decompressor(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     // Size of decompression buffer
     const BLOCK_SIZE: usize = 900 * 1024;

--- a/src/extractors/common.rs
+++ b/src/extractors/common.rs
@@ -24,7 +24,7 @@ pub struct ExtractionError;
 
 /// Built-in internal extractors must provide a function conforming to this definition.
 /// Arguments: file_data, offset, output_directory.
-pub type InternalExtractor = fn(&[u8], usize, Option<&String>) -> ExtractionResult;
+pub type InternalExtractor = fn(&[u8], usize, Option<&str>) -> ExtractionResult;
 
 /// Enum to define either an Internal or External extractor type
 #[derive(Debug, Default, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -104,7 +104,7 @@ impl Chroot {
     /// assert_eq!(std::path::Path::new(&chroot_dir).exists(), true);
     /// # std::fs::remove_dir_all(&chroot_dir);
     /// ```
-    pub fn new(chroot_directory: Option<&String>) -> Chroot {
+    pub fn new(chroot_directory: Option<&str>) -> Chroot {
         let mut chroot_instance = Chroot {
             ..Default::default()
         };
@@ -121,7 +121,7 @@ impl Chroot {
                         chroot_instance.chroot_directory = pathbuf.display().to_string();
                     }
                     Err(_) => {
-                        chroot_instance.chroot_directory = chroot_dir.clone();
+                        chroot_instance.chroot_directory = chroot_dir.to_string();
                     }
                 }
             }
@@ -781,7 +781,7 @@ impl Chroot {
     }
 
     /// Returns true if the file path is a symlink.
-    fn is_symlink(&self, file_path: &String) -> bool {
+    fn is_symlink(&self, file_path: &str) -> bool {
         if let Ok(metadata) = fs::symlink_metadata(file_path) {
             return metadata.file_type().is_symlink();
         }
@@ -856,7 +856,7 @@ impl Chroot {
 
 /// Recursively walks a given directory and returns a list of regular non-zero size files in the given directory path.
 #[allow(dead_code)]
-pub fn get_extracted_files(directory: &String) -> Vec<String> {
+pub fn get_extracted_files(directory: &str) -> Vec<String> {
     let mut regular_files: Vec<String> = vec![];
 
     for entry in WalkDir::new(directory).into_iter() {
@@ -884,7 +884,7 @@ pub fn get_extracted_files(directory: &String) -> Vec<String> {
 /// Executes an extractor for the provided SignatureResult.
 pub fn execute(
     file_data: &[u8],
-    file_path: &String,
+    file_path: &str,
     signature: &SignatureResult,
     extractor: &Option<Extractor>,
 ) -> ExtractionResult {
@@ -992,8 +992,8 @@ pub fn execute(
 /// Spawn an external extractor process.
 fn spawn(
     file_data: &[u8],
-    file_path: &String,
-    output_directory: &String,
+    file_path: &str,
+    output_directory: &str,
     signature: &SignatureResult,
     mut extractor: Extractor,
 ) -> Result<ProcInfo, std::io::Error> {
@@ -1143,7 +1143,7 @@ fn proc_wait(mut worker_info: ProcInfo) -> Result<ExtractionResult, ExtractionEr
 }
 
 // Create an output directory in which to place extraction results
-fn create_output_directory(file_path: &String, offset: usize) -> Result<String, std::io::Error> {
+fn create_output_directory(file_path: &str, offset: usize) -> Result<String, std::io::Error> {
     let chroot = Chroot::new(None);
 
     // Output directory will be: <file_path.extracted/<hex offset>
@@ -1167,7 +1167,7 @@ fn create_output_directory(file_path: &String, offset: usize) -> Result<String, 
 
 /// Returns true if the size of the provided extractor output directory is greater than zero.
 /// Note that any intermediate/carved files must be deleted *before* calling this function.
-fn was_something_extracted(output_directory: &String) -> bool {
+fn was_something_extracted(output_directory: &str) -> bool {
     let output_directory_path = path::Path::new(output_directory);
     debug!("Checking output directory {} for results", output_directory);
 

--- a/src/extractors/csman.rs
+++ b/src/extractors/csman.rs
@@ -37,7 +37,7 @@ pub fn csman_extractor() -> Extractor {
 pub fn extract_csman_dat(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const COMPRESSED_HEADER_SIZE: usize = 2;
 

--- a/src/extractors/dahua_zip.rs
+++ b/src/extractors/dahua_zip.rs
@@ -34,7 +34,7 @@ pub fn dahua_zip_extractor() -> Extractor {
 pub fn extract_dahua_zip(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const OUTFILE_NAME: &str = "dahua.zip";
     const ZIP_HEADER: &[u8] = b"PK";

--- a/src/extractors/dlink_tlv.rs
+++ b/src/extractors/dlink_tlv.rs
@@ -34,7 +34,7 @@ pub fn dlink_tlv_extractor() -> Extractor {
 pub fn extract_dlink_tlv_image(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const OUTPUT_FILE_NAME: &str = "image.bin";
 

--- a/src/extractors/dlke.rs
+++ b/src/extractors/dlke.rs
@@ -34,7 +34,7 @@ pub fn dlke_extractor() -> Extractor {
 pub fn extract_dlke_image(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const ENCRYPTED_FILE_NAME: &str = "encrypted.bin";
     const SIGNATURE_FILE_NAME: &str = "signature.bin";

--- a/src/extractors/dtb.rs
+++ b/src/extractors/dtb.rs
@@ -36,7 +36,7 @@ pub fn dtb_extractor() -> Extractor {
 pub fn extract_dtb(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     let mut heirerarchy: Vec<String> = Vec::new();
 

--- a/src/extractors/dxbc.rs
+++ b/src/extractors/dxbc.rs
@@ -34,7 +34,7 @@ pub fn dxbc_extractor() -> Extractor {
 pub fn extract_dxbc_file(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const OUTFILE_NAME: &str = "shader.dxbc";
 

--- a/src/extractors/gif.rs
+++ b/src/extractors/gif.rs
@@ -37,7 +37,7 @@ pub fn gif_extractor() -> Extractor {
 pub fn extract_gif_image(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const OUTFILE_NAME: &str = "image.gif";
 

--- a/src/extractors/gpg.rs
+++ b/src/extractors/gpg.rs
@@ -34,7 +34,7 @@ pub fn gpg_extractor() -> Extractor {
 pub fn gpg_decompress(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     // Size of the GPG header
     const HEADER_SIZE: usize = 2;

--- a/src/extractors/gzip.rs
+++ b/src/extractors/gzip.rs
@@ -35,7 +35,7 @@ pub fn gzip_extractor() -> Extractor {
 pub fn gzip_decompress(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     let mut exresult = ExtractionResult {
         ..Default::default()

--- a/src/extractors/inflate.rs
+++ b/src/extractors/inflate.rs
@@ -15,7 +15,7 @@ pub struct DeflateResult {
 pub fn inflate_decompressor(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> DeflateResult {
     // Size of decompression buffer
     const BLOCK_SIZE: usize = 8192;

--- a/src/extractors/jboot.rs
+++ b/src/extractors/jboot.rs
@@ -35,7 +35,7 @@ pub fn sch2_extractor() -> Extractor {
 pub fn extract_jboot_sch2_kernel(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     // Output file name
     const OUTFILE_NAME: &str = "kernel.bin";

--- a/src/extractors/jpeg.rs
+++ b/src/extractors/jpeg.rs
@@ -34,7 +34,7 @@ pub fn jpeg_extractor() -> Extractor {
 pub fn extract_jpeg_image(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const OUTFILE_NAME: &str = "image.jpg";
 

--- a/src/extractors/lzma.rs
+++ b/src/extractors/lzma.rs
@@ -34,7 +34,7 @@ pub fn lzma_extractor() -> Extractor {
 pub fn lzma_decompress(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     // Output file name
     const OUTPUT_FILE_NAME: &str = "decompressed.bin";

--- a/src/extractors/mbr.rs
+++ b/src/extractors/mbr.rs
@@ -34,7 +34,7 @@ pub fn mbr_extractor() -> Extractor {
 pub fn extract_mbr_partitions(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     // Return value
     let mut result = ExtractionResult {

--- a/src/extractors/mh01.rs
+++ b/src/extractors/mh01.rs
@@ -34,7 +34,7 @@ pub fn mh01_extractor() -> Extractor {
 pub fn extract_mh01_image(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     // File names for the three portions of the MH01 firmware image
     const IV_FILE_NAME: &str = "iv.bin";

--- a/src/extractors/pcap.rs
+++ b/src/extractors/pcap.rs
@@ -36,7 +36,7 @@ pub fn pcapng_extractor() -> Extractor {
 pub fn pcapng_carver(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     // Output file name
     const OUTPUT_FILE_NAME: &str = "capture.pcapng";

--- a/src/extractors/pem.rs
+++ b/src/extractors/pem.rs
@@ -64,7 +64,7 @@ pub fn pem_certificate_extractor() -> Extractor {
 pub fn pem_certificate_carver(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const CERTIFICATE_FILE_NAME: &str = "pem.crt";
     pem_carver(
@@ -78,7 +78,7 @@ pub fn pem_certificate_carver(
 pub fn pem_key_carver(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const KEY_FILE_NAME: &str = "pem.key";
     pem_carver(file_data, offset, output_directory, Some(KEY_FILE_NAME))
@@ -87,7 +87,7 @@ pub fn pem_key_carver(
 pub fn pem_carver(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
     fname: Option<&str>,
 ) -> ExtractionResult {
     let mut result = ExtractionResult {

--- a/src/extractors/png.rs
+++ b/src/extractors/png.rs
@@ -35,7 +35,7 @@ pub fn png_extractor() -> Extractor {
 pub fn extract_png_image(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const PNG_HEADER_LEN: usize = 8;
     const OUTFILE_NAME: &str = "image.png";

--- a/src/extractors/riff.rs
+++ b/src/extractors/riff.rs
@@ -35,7 +35,7 @@ pub fn riff_extractor() -> Extractor {
 pub fn extract_riff_image(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const OUTFILE_NAME: &str = "image.riff";
     const WAV_OUTFILE_NAME: &str = "video.wav";

--- a/src/extractors/romfs.rs
+++ b/src/extractors/romfs.rs
@@ -59,7 +59,7 @@ pub fn romfs_extractor() -> Extractor {
 pub fn extract_romfs(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     let mut result = ExtractionResult {
         ..Default::default()
@@ -228,8 +228,8 @@ fn process_romfs_entries(
 fn extract_romfs_entries(
     romfs_data: &[u8],
     romfs_files: &Vec<RomFSEntry>,
-    parent_directory: &String,
-    chroot_directory: &String,
+    parent_directory: &str,
+    chroot_directory: &str,
 ) -> usize {
     let mut file_count: usize = 0;
 

--- a/src/extractors/shrs.rs
+++ b/src/extractors/shrs.rs
@@ -34,7 +34,7 @@ pub fn shrs_extractor() -> Extractor {
 pub fn extract_shrs_image(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const IV_FILE_NAME: &str = "iv.bin";
     const ENCRYPTED_FILE_NAME: &str = "encrypted.bin";

--- a/src/extractors/svg.rs
+++ b/src/extractors/svg.rs
@@ -35,7 +35,7 @@ pub fn svg_extractor() -> Extractor {
 pub fn extract_svg_image(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const OUTFILE_NAME: &str = "image.svg";
 

--- a/src/extractors/swapped.rs
+++ b/src/extractors/swapped.rs
@@ -33,7 +33,7 @@ pub fn swapped_extractor_u16() -> Extractor {
 pub fn extract_swapped_u16(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const SWAP_BYTE_COUNT: usize = 2;
     extract_swapped(file_data, offset, output_directory, SWAP_BYTE_COUNT)
@@ -43,7 +43,7 @@ pub fn extract_swapped_u16(
 fn extract_swapped(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
     n: usize,
 ) -> ExtractionResult {
     const OUTPUT_FILE_NAME: &str = "swapped.bin";

--- a/src/extractors/trx.rs
+++ b/src/extractors/trx.rs
@@ -35,7 +35,7 @@ pub fn trx_extractor() -> Extractor {
 pub fn extract_trx_partitions(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const CRC_DATA_START_OFFSET: usize = 12;
 

--- a/src/extractors/uimage.rs
+++ b/src/extractors/uimage.rs
@@ -34,7 +34,7 @@ pub fn uimage_extractor() -> Extractor {
 pub fn extract_uimage(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     // If no name is povided in the uImage header, use this as the output file name
     const DEFAULT_OUTPUT_FILE_NAME: &str = "uimage_data";

--- a/src/extractors/vxworks.rs
+++ b/src/extractors/vxworks.rs
@@ -40,7 +40,7 @@ pub fn vxworks_symtab_extractor() -> Extractor {
 pub fn extract_symbol_table(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     const MIN_VALID_ENTRIES: usize = 250;
     const OUTFILE_NAME: &str = "symtab.json";

--- a/src/extractors/wince.rs
+++ b/src/extractors/wince.rs
@@ -35,7 +35,7 @@ pub fn wince_extractor() -> Extractor {
 pub fn wince_dump(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     let mut result = ExtractionResult {
         ..Default::default()

--- a/src/extractors/zlib.rs
+++ b/src/extractors/zlib.rs
@@ -37,7 +37,7 @@ pub fn zlib_extractor() -> Extractor {
 pub fn zlib_decompress(
     file_data: &[u8],
     offset: usize,
-    output_directory: Option<&String>,
+    output_directory: Option<&str>,
 ) -> ExtractionResult {
     // Size of the zlib header
     const HEADER_SIZE: usize = 2;


### PR DESCRIPTION
- `&str` provides better generality than `&String` in function parameters.