### PR TITLE
Fixed riff signature for files other than webp and fix chunk type

### DIFF
--- a/src/structures/riff.rs
+++ b/src/structures/riff.rs
@@ -8,26 +8,24 @@ pub struct RIFFHeader {
 
 /// Parse a RIFF image header
 pub fn parse_riff_header(riff_data: &[u8]) -> Result<RIFFHeader, StructureError> {
-    const MAGIC1: usize = 0x46464952;
-    const MAGIC2: usize = 0x50424557;
+    const MAGIC: usize = 0x46464952;
 
-    const CHUNK_TYPE_START: usize = 12;
-    const CHUNK_TYPE_END: usize = 15;
+    const CHUNK_TYPE_START: usize = 8;
+    const CHUNK_TYPE_END: usize = 12;
 
     const FILE_SIZE_OFFSET: usize = 8;
 
     let riff_structure = vec![
-        ("magic1", "u32"),
+        ("magic", "u32"),
         ("file_size", "u32"),
-        ("magic2", "u32"),
         ("chunk_type", "u32"),
     ];
 
     // Parse the riff header
     if let Ok(riff_header) = common::parse(riff_data, &riff_structure, "little") {
         // Sanity check expected magic bytes
-        if riff_header["magic1"] == MAGIC1 && riff_header["magic2"] == MAGIC2 {
-            // Get the RIFF type string (e.g., "WAV")
+        if riff_header["magic"] == MAGIC {
+            // Get the RIFF type string (e.g., "WAVE")
             if let Ok(type_string) =
                 String::from_utf8(riff_data[CHUNK_TYPE_START..CHUNK_TYPE_END].to_vec())
             {


### PR DESCRIPTION
Fixes #810
I noticed the chunk type was not being read correctly so that is also fixed