### PR TITLE
feat: add md5 hash constants to hashes.rs signatures

### DIFF
--- a/src/magic.rs
+++ b/src/magic.rs
@@ -159,6 +159,17 @@ pub fn patterns() -> Vec<signatures::common::Signature> {
             description: signatures::hashes::SHA256_DESCRIPTION.to_string(),
             extractor: None,
         },
+        // md5 constants
+        signatures::common::Signature {
+            name: "md5".to_string(),
+            short: false,
+            magic_offset: 0,
+            always_display: false,
+            magic: signatures::hashes::md5_magic(),
+            parser: signatures::hashes::md5_parser,
+            description: signatures::hashes::MD5_DESCRIPTION.to_string(),
+            extractor: None,
+        },
         // cpio
         signatures::common::Signature {
             name: "cpio".to_string(),

--- a/src/signatures/hashes.rs
+++ b/src/signatures/hashes.rs
@@ -6,6 +6,7 @@ const HASH_MAGIC_LEN: usize = 16;
 /// Human readable descriptions
 pub const CRC32_DESCRIPTION: &str = "CRC32 polynomial table";
 pub const SHA256_DESCRIPTION: &str = "SHA256 hash constants";
+pub const MD5_DESCRIPTION: &str = "MD5 hash constants";
 
 /// CRC32 contstants
 pub fn crc32_magic() -> Vec<Vec<u8>> {
@@ -26,6 +27,17 @@ pub fn sha256_magic() -> Vec<Vec<u8>> {
         b"\x42\x8a\x2f\x98\x71\x37\x44\x91\xb5\xc0\xfb\xcf\xe9\xb5\xdb\xa5".to_vec(),
         // Little endian
         b"\x98\x2f\x8a\x42\x91\x44\x37\x71\xcf\xfb\xc0\xb5\xa5\xdb\xb5\xe9".to_vec(),
+    ]
+}
+
+/// MD5 constants
+pub fn md5_magic() -> Vec<Vec<u8>> {
+    // Order matters! See hash_endianness().
+    vec![
+        // Big endian
+        b"\xd7\x6a\xa4\x78\xe8\xc7\xb7\x56\x24\x20\x70\xdb\xc1\xbd\xce\xee".to_vec(),
+        // Little endian
+        b"\x78\xa4\x6a\xd7\x56\xb7\xc7\xe8\xdb\x70\x20\x24\xee\xce\xbd\xc1".to_vec(),
     ]
 }
 
@@ -52,6 +64,22 @@ pub fn sha256_parser(file_data: &[u8], offset: usize) -> Result<SignatureResult,
             "{}, {} endian",
             SHA256_DESCRIPTION,
             hash_endianess(file_data, offset, sha256_magic())
+        ),
+        offset,
+        size: HASH_MAGIC_LEN,
+        ..Default::default()
+    };
+
+    Ok(result)
+}
+
+pub fn md5_parser(file_data: &[u8], offset: usize) -> Result<SignatureResult, SignatureError> {
+    // Just return a success with some extra description info
+    let result = SignatureResult {
+        description: format!(
+            "{}, {} endian",
+            MD5_DESCRIPTION,
+            hash_endianess(file_data, offset, md5_magic())
         ),
         offset,
         size: HASH_MAGIC_LEN,


### PR DESCRIPTION
This commit adds the K (or T) table from the MD5 algorithm as constants in `hashes.rs`