### PR TITLE
Update docker base to Ubuntu 25.04, and update dependencies  (again)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN apt-get update -y \
     clang \
     && dpkg -i ${BUILD_DIR}/${SASQUATCH_FILENAME} \
     && rm ${BUILD_DIR}/${SASQUATCH_FILENAME} \
-    && CC=clang uv pip install uefi_firmware jefferson jefferson ubi-reader git+https://github.com/marin-m/vmlinux-to-elf \
+    && CC=clang uv pip install uefi_firmware jefferson ubi-reader git+https://github.com/marin-m/vmlinux-to-elf \
     && uv cache clean \
     && apt-get purge clang -y \
     && apt autoremove -y \


### PR DESCRIPTION
This PR is functionally the same as #860 that was partially overridden/reverted by #869 :

1. Update docker base to `ubuntu:25.04`, for both the builder and the "production" images. 
2. Remove `git+https://github.com/clubby789/python-lzo@b4e39df` python dependency (it is not a direct dependency of binwalk, it is a dependency of  `vmlinux-to-elf ` and its `setup.py` specifies its dependencies)
3. Remove building `7zzs` from source, as it is not used (its usage was removed in #860, and this change was not reverted). 
4. Update `sasquatch`.
5. Use `uv` for installing python packages
6. Remove extra "}" in some variables in the Dockerfile.