### PR TITLE
Fix missing quotes around path

### DIFF
--- a/dependencies/ubuntu.sh
+++ b/dependencies/ubuntu.sh
@@ -40,7 +40,7 @@ dpkg -i sasquatch_1.0.deb
 rm sasquatch_1.0.deb
 
 # Install Python dependencies
-source ${SCRIPT_DIRECTORY}/pip.sh
+source "${SCRIPT_DIRECTORY}/pip.sh"
 
 # Install dependencies from source
-source ${SCRIPT_DIRECTORY}/src.sh
+source "${SCRIPT_DIRECTORY}/src.sh"


### PR DESCRIPTION
By not quoting the SCRIPT_DIRECTORY variable, the script fails when located in paths with spaces in their name