### PR TITLE
Package binwalk using maturin to make it pip installable

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,64 @@
+name: Build and publish Python wheels (maturin)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  id-token: write  # Required for PyPI Trusted Publishing
+  contents: read
+
+jobs:
+  build:
+    name: Build wheels and sdist with maturin (bindings=bin)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install maturin
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install maturin
+
+    - name: Build wheels with maturin
+      working-directory: pypi
+      run: |
+        maturin build --release -o ../wheelhouse
+
+    - name: Build sdist with maturin
+      working-directory: pypi
+      run: |
+        maturin sdist -o ../wheelhouse
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-${{ matrix.os }}
+        path: wheelhouse/*
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all wheel artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: dist
+
+    - name: Publish to PyPI (Trusted Publishing)
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: dist

--- a/pypi/README.md
+++ b/pypi/README.md
@@ -1,0 +1,3 @@
+# binwalk Python package
+
+This package provides a copy of the `binwalk` tool compiled for a variety of OS and architectures, allowing installation via `pip`.

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["maturin>=1.5,<2"]
+build-backend = "maturin"
+
+[project]
+name = "binwalk"
+description = "pip installable package for binwalk"
+readme = "README.md"
+authors = [{ name = "Craig Heffner", email = "heffnercj@gmail.com" }]
+license = { file = "../LICENSE" }
+requires-python = ">=3.8"
+keywords = ["binwalk", "firmware", "reverse-engineering", "rust"]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX :: Linux",
+]
+
+[project.urls]
+Homepage = "https://github.com/nightlark/binwalk"
+Issues = "https://github.com/nightlark/binwalk/issues"
+
+[tool.maturin]
+# Build the Rust binary as a Python CLI using maturin's `bindings = "bin"`.
+bindings = "bin"
+# Point maturin at the crate manifest in the repo root.
+manifest-path = "../Cargo.toml"
+# Name of the exposed module/CLI (sets the wheel name and console script).
+module-name = "binwalk"
+
+## No [project.scripts] needed; maturin will generate the console entrypoint in bin mode


### PR DESCRIPTION
This makes so that Python wheels can be built for binwalk, enabling binwalk to be pip installed. It includes a CI workflow for building wheels on a variety of platforms. The publishing portion of the workflow likely will need some adjustments.

Resolves #732 